### PR TITLE
refactor: Move to libunwind instead of backtrace.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ mf_test.o : mf_test.c
 	$(CC) -c $(CFLAGS) -o $@ $<
 
 mallocfail.so : mallocfail.o memory_funcs.o sha3.o
-	$(CC) -shared -o $@ $^ ${LDFLAGS} -fPIC -ldl -lbacktrace
+	$(CC) -shared -o $@ $^ ${LDFLAGS} -fPIC -ldl -lunwind
 
 mf_test : mf_test.o
 	$(CC) -o $@ $^ ${LDFLAGS}

--- a/deps/sha3/sha3.h
+++ b/deps/sha3/sha3.h
@@ -1,19 +1,21 @@
 #ifndef SHA3_H
 #define SHA3_H
 
+#include <stdint.h>
+
 /* -------------------------------------------------------------------------
- * Works when compiled for either 32-bit or 64-bit targets, optimized for 
+ * Works when compiled for either 32-bit or 64-bit targets, optimized for
  * 64 bit.
  *
- * Canonical implementation of Init/Update/Finalize for SHA-3 byte input. 
+ * Canonical implementation of Init/Update/Finalize for SHA-3 byte input.
  *
  * SHA3-256, SHA3-384, SHA-512 are implemented. SHA-224 can easily be added.
  *
  * Based on code from http://keccak.noekeon.org/ .
  *
- * I place the code that I wrote into public domain, free to use. 
+ * I place the code that I wrote into public domain, free to use.
  *
- * I would appreciate if you give credits to this work if you used it to 
+ * I would appreciate if you give credits to this work if you used it to
  * write or test * your code.
  *
  * Aug 2015. Andrey Jivsov. crypto@brainhub.org

--- a/src/mallocfail.c
+++ b/src/mallocfail.c
@@ -18,22 +18,21 @@ efficient and reliable than e.g. random testing.
 
 #define uthash_malloc libc_malloc
 
-#include "uthash.h"
-#include "sha3.h"
-
-#include <stdio.h>
-#include <string.h>
 #include <execinfo.h>
-
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 
+#include "sha3.h"
+#include "uthash.h"
+
+#define UNW_LOCAL_ONLY
+#include <libunwind.h>
 #include <unistd.h>
-#include <backtrace.h>
 
-#define HASH_BITS 256
-#define HASH_BYTES ((HASH_BITS)/8)
-#define HASH_HEX_BYTES ((HASH_BITS)/4)
+#define HASH_BITS      256
+#define HASH_BYTES     ((HASH_BITS) / 8)
+#define HASH_HEX_BYTES ((HASH_BITS) / 4)
 
 extern int force_libc;
 extern void *(*libc_malloc)(size_t);
@@ -41,202 +40,196 @@ extern void *(*libc_calloc)(size_t, size_t);
 extern void *(*libc_realloc)(void *, size_t);
 
 struct traces_s {
-	UT_hash_handle hh;
-	char hash[HASH_HEX_BYTES+1];
+    UT_hash_handle hh;
+    char hash[HASH_HEX_BYTES + 1];
 };
 
 static struct traces_s *traces = NULL;
-static struct backtrace_state *state = NULL;
 static char strbuf[1024];
 static char *hashfile = NULL;
 static char hashfile_default[] = "mallocfail_hashes";
 static int debug = -1;
-static int backtrace_count;
 static int fail_count = 0;
 static int max_fail_count = -1;
 
-
 static void hex_encode(const unsigned char *in, unsigned int in_len, char *encoded)
 {
-	int i;
-	for(i=0; i<in_len; i++){
-		sprintf(&encoded[i*2], "%02x", in[i]);
-	}
+    int i;
+    for (i = 0; i < in_len; i++) {
+        sprintf(&encoded[i * 2], "%02x", in[i]);
+    }
 }
-
 
 static int append_stack_context(const char *filename, const char *hash_str)
 {
-	FILE *fptr;
+    FILE *fptr;
 
-	struct traces_s *t = libc_malloc(sizeof(struct traces_s));
-	memcpy(t->hash, hash_str, HASH_HEX_BYTES);
-	t->hash[HASH_HEX_BYTES] = '\0';
-	HASH_ADD_STR(traces, hash, t);
+    struct traces_s *t = (struct traces_s *)libc_malloc(sizeof(struct traces_s));
+    memcpy(t->hash, hash_str, HASH_HEX_BYTES);
+    t->hash[HASH_HEX_BYTES] = '\0';
+    HASH_ADD_STR(traces, hash, t);
 
-	fptr = fopen(filename, "at");
-	if(!fptr){
-		return 1;
-	}
-	fprintf(fptr, "%s\n", hash_str);
+    fptr = fopen(filename, "at");
+    if (!fptr) {
+        return 1;
+    }
+    fprintf(fptr, "%s\n", hash_str);
 
-	fclose(fptr);
-	return 0;
+    fclose(fptr);
+    return 0;
 }
-
 
 static void load_traces(const char *filename)
 {
-	FILE *fptr;
-	char buf[1024];
+    FILE *fptr;
+    char buf[1024];
 
-	fptr = fopen(filename, "rt");
-	if(!fptr){
-		return;
-	}
+    fptr = fopen(filename, "rt");
+    if (!fptr) {
+        return;
+    }
 
-	while(!feof(fptr)){
-		if(fgets(buf, 1024, fptr)){
-			if(buf[strlen(buf)-1] == '\n'){
-				buf[strlen(buf)-1] = '\0';
-				
-				struct traces_s *t = libc_malloc(sizeof(struct traces_s));
-				memcpy(t->hash, buf, HASH_HEX_BYTES);
-				t->hash[HASH_HEX_BYTES] = '\0';
-				HASH_ADD_STR(traces, hash, t);
-			}
-		}
-	}
-	fclose(fptr);
+    while (!feof(fptr)) {
+        if (fgets(buf, 1024, fptr)) {
+            if (buf[strlen(buf) - 1] == '\n') {
+                buf[strlen(buf) - 1] = '\0';
+
+                struct traces_s *t = (struct traces_s *)libc_malloc(sizeof(struct traces_s));
+                memcpy(t->hash, buf, HASH_HEX_BYTES);
+                t->hash[HASH_HEX_BYTES] = '\0';
+                HASH_ADD_STR(traces, hash, t);
+            }
+        }
+    }
+    fclose(fptr);
 }
-
 
 static int stack_context_exists(const char *filename, const char *hash_str)
 {
-	struct traces_s *found_trace;
-	int rc;
+    struct traces_s *found_trace;
+    int rc;
 
-	force_libc = 1;
-	if(traces == NULL){
-		load_traces(filename);
-	}
+    force_libc = 1;
+    if (traces == NULL) {
+        load_traces(filename);
+    }
 
-	HASH_FIND_STR(traces, hash_str, found_trace);
-	if(found_trace){
-		rc = 1;
-	}else{
-		append_stack_context(filename, hash_str);
-		rc = 0;
-	}
+    HASH_FIND_STR(traces, hash_str, found_trace);
+    if (found_trace) {
+        rc = 1;
+    } else {
+        append_stack_context(filename, hash_str);
+        rc = 0;
+    }
 
-	force_libc = 0;
-	return rc;
+    force_libc = 0;
+    return rc;
 }
-
-
-static int backtrace_callback(void *data, uintptr_t pc, const char *filename, int lineno, const char *function)
-{
-	int len;
-	sha3_context *hash_context = (sha3_context *)data;
-
-	if(lineno){
-		len = snprintf(strbuf, 1024, "%s:%s:%d\n", filename, function, lineno);
-		sha3_Update(hash_context, strbuf, len);
-	}
-
-	return 0;
-}
-
 
 static void create_backtrace_hash(char *hash_str)
 {
-	const unsigned char *hash;
-	sha3_context hash_context;
+    const unsigned char *hash;
+    sha3_context hash_context;
 
-	force_libc = 1;
+    force_libc = 1;
 
-	sha3_Init256(&hash_context);
-	backtrace_full(state, 0, backtrace_callback, NULL, &hash_context);
-	hash = sha3_Finalize(&hash_context);
-	hex_encode(hash, HASH_BYTES, hash_str);
+    sha3_Init256(&hash_context);
 
-	force_libc = 0;
+    unw_cursor_t cursor;
+    unw_context_t uc;
+
+    unw_getcontext(&uc);
+    unw_init_local(&cursor, &uc);
+    while (unw_step(&cursor) > 0) {
+        unw_word_t ip, sp, off;
+        unw_get_reg(&cursor, UNW_REG_IP, &ip);
+        unw_get_reg(&cursor, UNW_REG_SP, &sp);
+
+        char symbol[256] = "<unknown>";
+        unw_get_proc_name(&cursor, symbol, sizeof(symbol), &off);
+
+        int len = snprintf(strbuf, 1024, "%s %lx\n", symbol, (long)off);
+        sha3_Update(&hash_context, strbuf, len);
+    }
+
+    hash = sha3_Finalize(&hash_context);
+    hex_encode(hash, HASH_BYTES, hash_str);
+
+    force_libc = 0;
 }
-
-
-static int backtrace_print_callback(void *data, uintptr_t pc, const char *filename, int lineno, const char *function)
-{
-	if(lineno && ++backtrace_count > -3){
-		printf("%s:%s:%d\n", filename, function, lineno);
-	}
-
-	return 0;
-}
-
 
 static void print_backtrace(void)
 {
-	force_libc = 1;
-	printf("------- Start trace -------\n");
-	backtrace_count = 0;
-	backtrace_full(state, 0, backtrace_print_callback, NULL, NULL);
-	printf("------- End trace -------\n");
-	force_libc = 0;
-}
+    force_libc = 1;
+    printf("------- Start trace -------\n");
 
+    unw_cursor_t cursor;
+    unw_context_t uc;
+
+    unw_getcontext(&uc);
+    unw_init_local(&cursor, &uc);
+    while (unw_step(&cursor) > 0) {
+        unw_word_t ip, sp, off;
+        unw_get_reg(&cursor, UNW_REG_IP, &ip);
+        unw_get_reg(&cursor, UNW_REG_SP, &sp);
+
+        char symbol[256] = "<unknown>";
+        unw_get_proc_name(&cursor, symbol, sizeof(symbol), &off);
+
+        printf("%s %lx\n", symbol, (long)off);
+    }
+
+    printf("------- End trace -------\n");
+    force_libc = 0;
+}
 
 int should_malloc_fail(void)
 {
-	char hash_str[1024];
-	int exists;
+    char hash_str[1024];
+    int exists;
 
-	if(max_fail_count == -1){
-		char *env = getenv("MALLOCFAIL_FAIL_COUNT");
-		if(env){
-			max_fail_count = atoi(env);
-			if(max_fail_count < 0){
-				max_fail_count = 0;
-			}
-		}else{
-			max_fail_count = 0;
-		}
-	}
+    if (max_fail_count == -1) {
+        char *env = getenv("MALLOCFAIL_FAIL_COUNT");
+        if (env) {
+            max_fail_count = atoi(env);
+            if (max_fail_count < 0) {
+                max_fail_count = 0;
+            }
+        } else {
+            max_fail_count = 0;
+        }
+    }
 
-	if(max_fail_count > 0 && fail_count >= max_fail_count){
-		return 0;
-	}
+    if (max_fail_count > 0 && fail_count >= max_fail_count) {
+        return 0;
+    }
 
-	if(!state){
-		state = backtrace_create_state(NULL, 1, NULL, NULL);
-	}
+    force_libc = 1;
+    if (!hashfile) {
+        hashfile = getenv("MALLOCFAIL_FILE");
+        if (!hashfile) {
+            hashfile = hashfile_default;
+        }
+    }
 
-	force_libc = 1;
-	if(!hashfile){
-		hashfile = getenv("MALLOCFAIL_FILE");
-		if(!hashfile){
-			hashfile = hashfile_default;
-		}
-	}
+    if (debug == -1) {
+        if (getenv("MALLOCFAIL_DEBUG")) {
+            debug = 1;
+        } else {
+            debug = 0;
+        }
+    }
+    force_libc = 0;
 
-	if(debug == -1){
-		if(getenv("MALLOCFAIL_DEBUG")){
-			debug = 1;
-		}else{
-			debug = 0;
-		}
-	}
-	force_libc = 0;
-
-	create_backtrace_hash(hash_str);
-	exists = stack_context_exists(hashfile, hash_str);
-	if(!exists && debug){
-		print_backtrace();
-	}
-	if(exists){
-		return 0;
-	}else{
-		fail_count++;
-		return 1;
-	}
+    create_backtrace_hash(hash_str);
+    exists = stack_context_exists(hashfile, hash_str);
+    if (!exists && debug) {
+        print_backtrace();
+    }
+    if (exists) {
+        return 0;
+    } else {
+        fail_count++;
+        return 1;
+    }
 }
-

--- a/src/syscall_funcs.c
+++ b/src/syscall_funcs.c
@@ -1,0 +1,154 @@
+#define _GNU_SOURCE
+
+#include <dlfcn.h>
+#include <errno.h>
+#include <stdarg.h>
+#include <stdlib.h>
+#include <sys/ioctl.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+
+#include "mallocfail.h"
+
+static int (*libc_ioctl)(int fd, unsigned long request, ...);
+static int (*libc_bind)(int sockfd, const struct sockaddr *addr, socklen_t addrlen);
+static int (*libc_getsockopt)(int sockfd, int level, int optname, void *optval, socklen_t *optlen);
+static int (*libc_setsockopt)(
+    int sockfd, int level, int optname, const void *optval, socklen_t optlen);
+static ssize_t (*libc_recv)(int sockfd, void *buf, size_t len, int flags);
+static ssize_t (*libc_recvfrom)(
+    int sockfd, void *buf, size_t len, int flags, struct sockaddr *src_addr, socklen_t *addrlen);
+static ssize_t (*libc_send)(int sockfd, const void *buf, size_t len, int flags);
+static ssize_t (*libc_sendto)(int sockfd, const void *buf, size_t len, int flags,
+                              const struct sockaddr *dest_addr, socklen_t addrlen);
+static int (*libc_socket)(int domain, int type, int protocol);
+static int (*libc_listen)(int sockfd, int backlog);
+
+__attribute__((__constructor__)) static void init(void)
+{
+    libc_ioctl = dlsym(RTLD_NEXT, "ioctl");
+    libc_bind = dlsym(RTLD_NEXT, "bind");
+    libc_getsockopt = dlsym(RTLD_NEXT, "getsockopt");
+    libc_setsockopt = dlsym(RTLD_NEXT, "setsockopt");
+    libc_recv = dlsym(RTLD_NEXT, "recv");
+    libc_recvfrom = dlsym(RTLD_NEXT, "recvfrom");
+    libc_send = dlsym(RTLD_NEXT, "send");
+    libc_sendto = dlsym(RTLD_NEXT, "sendto");
+    libc_socket = dlsym(RTLD_NEXT, "socket");
+    libc_listen = dlsym(RTLD_NEXT, "listen");
+}
+
+int ioctl(int fd, unsigned long request, ...)
+{
+    if (should_malloc_fail()) {
+        errno = ENOMEM;
+        return -1;
+    }
+
+    va_list ap;
+    va_start(ap, request);
+    const int ret = libc_ioctl(fd, SIOCGIFCONF, va_arg(ap, void *));
+    va_end(ap);
+    return ret;
+}
+
+int bind(int sockfd, const struct sockaddr *addr, socklen_t addrlen)
+{
+    // Unlike all others, if bind should fail once, it should fail always, because in toxcore we try
+    // many ports before giving up. If this only fails once, we'll never reach the code path where
+    // we give up.
+    static int should_fail = -1;
+
+    if (should_fail == -1) {
+        should_fail = should_malloc_fail();
+    }
+
+    if (should_fail) {
+        errno = ENOMEM;
+        return -1;
+    }
+
+    return libc_bind(sockfd, addr, addrlen);
+}
+
+int getsockopt(int sockfd, int level, int optname, void *optval, socklen_t *optlen)
+{
+    if (should_malloc_fail()) {
+        errno = ENOMEM;
+        return -1;
+    }
+
+    return libc_getsockopt(sockfd, level, optname, optval, optlen);
+}
+
+int setsockopt(int sockfd, int level, int optname, const void *optval, socklen_t optlen)
+{
+    if (should_malloc_fail()) {
+        errno = ENOMEM;
+        return -1;
+    }
+
+    return libc_setsockopt(sockfd, level, optname, optval, optlen);
+}
+
+ssize_t recv(int sockfd, void *buf, size_t len, int flags)
+{
+    if (should_malloc_fail()) {
+        errno = ENOMEM;
+        return -1;
+    }
+
+    return libc_recv(sockfd, buf, len, flags);
+}
+
+ssize_t recvfrom(
+    int sockfd, void *buf, size_t len, int flags, struct sockaddr *src_addr, socklen_t *addrlen)
+{
+    if (should_malloc_fail()) {
+        errno = ENOMEM;
+        return -1;
+    }
+
+    return libc_recvfrom(sockfd, buf, len, flags, src_addr, addrlen);
+}
+
+ssize_t send(int sockfd, const void *buf, size_t len, int flags)
+{
+    if (should_malloc_fail()) {
+        errno = ENOMEM;
+        return -1;
+    }
+
+    return libc_send(sockfd, buf, len, flags);
+}
+
+ssize_t sendto(int sockfd, const void *buf, size_t len, int flags, const struct sockaddr *dest_addr,
+               socklen_t addrlen)
+{
+    if (should_malloc_fail()) {
+        errno = ENOMEM;
+        return -1;
+    }
+
+    return libc_sendto(sockfd, buf, len, flags, dest_addr, addrlen);
+}
+
+int socket(int domain, int type, int protocol)
+{
+    if (should_malloc_fail()) {
+        errno = ENOMEM;
+        return -1;
+    }
+
+    return libc_socket(domain, type, protocol);
+}
+
+int listen(int sockfd, int backlog)
+{
+    if (should_malloc_fail()) {
+        errno = ENOMEM;
+        return -1;
+    }
+
+    return libc_listen(sockfd, backlog);
+}


### PR DESCRIPTION
libunwind is available across compilers, while backtrace only works on gcc. This is a problem, because clang-17 produces dwarf codes that gcc's backtrace doesn't understand (it segfaults).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/mallocfail/1)
<!-- Reviewable:end -->
