### PR TITLE
refactor: Move to libunwind instead of backtrace.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,22 @@
+BasedOnStyle: WebKit
+ColumnLimit: 100
+PointerAlignment: Right
+SpacesBeforeTrailingComments: 2
+AlignConsecutiveMacros: true
+AlignEscapedNewlines: Left
+AlwaysBreakTemplateDeclarations: Yes
+SpaceBeforeCpp11BracedList: false
+Cpp11BracedListStyle: true
+
+IncludeIsMainRegex: '([-_](test|fuzz_test))?$'
+IncludeBlocks: Regroup
+IncludeCategories:
+  - Regex:           '^<.*\.h>'
+    Priority:        1
+    SortPriority:    0
+  - Regex:           '^<.*'
+    Priority:        2
+    SortPriority:    0
+  - Regex:           '.*'
+    Priority:        3
+    SortPriority:    0

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ mf_test.o : mf_test.c
 	$(CC) -c $(CFLAGS) -o $@ $<
 
 mallocfail.so : mallocfail.o memory_funcs.o sha3.o
-	$(CC) -shared -o $@ $^ ${LDFLAGS} -fPIC -ldl -lbacktrace
+	$(CC) -shared -o $@ $^ ${LDFLAGS} -fPIC -ldl -lunwind
 
 mf_test : mf_test.o
 	$(CC) -o $@ $^ ${LDFLAGS}
@@ -36,4 +36,3 @@ install : mallocfail.so
 	$(INSTALL) mallocfail.so ${DESTDIR}${prefix}/lib/mallocfail.so
 	$(INSTALL) mallocfail ${DESTDIR}${prefix}/bin/mallocfail
 	sed -i "s#/usr/local#${prefix}#" ${DESTDIR}${prefix}/bin/mallocfail
-

--- a/deps/sha3/sha3.c
+++ b/deps/sha3/sha3.c
@@ -1,41 +1,41 @@
 /* -------------------------------------------------------------------------
- * Works when compiled for either 32-bit or 64-bit targets, optimized for 
+ * Works when compiled for either 32-bit or 64-bit targets, optimized for
  * 64 bit.
  *
- * Canonical implementation of Init/Update/Finalize for SHA-3 byte input. 
+ * Canonical implementation of Init/Update/Finalize for SHA-3 byte input.
  *
  * SHA3-256, SHA3-384, SHA-512 are implemented. SHA-224 can easily be added.
  *
  * Based on code from http://keccak.noekeon.org/ .
  *
- * I place the code that I wrote into public domain, free to use. 
+ * I place the code that I wrote into public domain, free to use.
  *
- * I would appreciate if you give credits to this work if you used it to 
+ * I would appreciate if you give credits to this work if you used it to
  * write or test * your code.
  *
  * Aug 2015. Andrey Jivsov. crypto@brainhub.org
  * ---------------------------------------------------------------------- */
 
-#include <stdio.h>
-#include <stdint.h>
-#include <string.h>
-
 #include "sha3.h"
 
-#define SHA3_ASSERT( x )
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+#define SHA3_ASSERT(x)
 #if defined(_MSC_VER)
-#define SHA3_TRACE( format, ...)
-#define SHA3_TRACE_BUF( format, buf, l, ...)
+#define SHA3_TRACE(format, ...)
+#define SHA3_TRACE_BUF(format, buf, l, ...)
 #else
 #define SHA3_TRACE(format, args...)
 #define SHA3_TRACE_BUF(format, buf, l, args...)
 #endif
 
-//#define SHA3_USE_KECCAK
-/* 
+// #define SHA3_USE_KECCAK
+/*
  * Define SHA3_USE_KECCAK to run "pure" Keccak, as opposed to SHA3.
  * The tests that this macro enables use the input and output from [Keccak]
- * (see the reference below). The used test vectors aren't correct for SHA3, 
+ * (see the reference below). The used test vectors aren't correct for SHA3,
  * however, they are helpful to verify the implementation.
  * SHA3_USE_KECCAK only changes one line of code in Finalize.
  */
@@ -47,60 +47,53 @@
 #endif
 
 #ifndef SHA3_ROTL64
-#define SHA3_ROTL64(x, y) \
-	(((x) << (y)) | ((x) >> ((sizeof(uint64_t)*8) - (y))))
+#define SHA3_ROTL64(x, y) (((x) << (y)) | ((x) >> ((sizeof(uint64_t) * 8) - (y))))
 #endif
 
-static const uint64_t keccakf_rndc[24] = {
-    SHA3_CONST(0x0000000000000001UL), SHA3_CONST(0x0000000000008082UL),
-    SHA3_CONST(0x800000000000808aUL), SHA3_CONST(0x8000000080008000UL),
-    SHA3_CONST(0x000000000000808bUL), SHA3_CONST(0x0000000080000001UL),
-    SHA3_CONST(0x8000000080008081UL), SHA3_CONST(0x8000000000008009UL),
-    SHA3_CONST(0x000000000000008aUL), SHA3_CONST(0x0000000000000088UL),
-    SHA3_CONST(0x0000000080008009UL), SHA3_CONST(0x000000008000000aUL),
-    SHA3_CONST(0x000000008000808bUL), SHA3_CONST(0x800000000000008bUL),
-    SHA3_CONST(0x8000000000008089UL), SHA3_CONST(0x8000000000008003UL),
-    SHA3_CONST(0x8000000000008002UL), SHA3_CONST(0x8000000000000080UL),
-    SHA3_CONST(0x000000000000800aUL), SHA3_CONST(0x800000008000000aUL),
-    SHA3_CONST(0x8000000080008081UL), SHA3_CONST(0x8000000000008080UL),
-    SHA3_CONST(0x0000000080000001UL), SHA3_CONST(0x8000000080008008UL)
-};
+static const uint64_t keccakf_rndc[24]
+    = {SHA3_CONST(0x0000000000000001UL), SHA3_CONST(0x0000000000008082UL),
+        SHA3_CONST(0x800000000000808aUL), SHA3_CONST(0x8000000080008000UL),
+        SHA3_CONST(0x000000000000808bUL), SHA3_CONST(0x0000000080000001UL),
+        SHA3_CONST(0x8000000080008081UL), SHA3_CONST(0x8000000000008009UL),
+        SHA3_CONST(0x000000000000008aUL), SHA3_CONST(0x0000000000000088UL),
+        SHA3_CONST(0x0000000080008009UL), SHA3_CONST(0x000000008000000aUL),
+        SHA3_CONST(0x000000008000808bUL), SHA3_CONST(0x800000000000008bUL),
+        SHA3_CONST(0x8000000000008089UL), SHA3_CONST(0x8000000000008003UL),
+        SHA3_CONST(0x8000000000008002UL), SHA3_CONST(0x8000000000000080UL),
+        SHA3_CONST(0x000000000000800aUL), SHA3_CONST(0x800000008000000aUL),
+        SHA3_CONST(0x8000000080008081UL), SHA3_CONST(0x8000000000008080UL),
+        SHA3_CONST(0x0000000080000001UL), SHA3_CONST(0x8000000080008008UL)};
 
-static const unsigned keccakf_rotc[24] = {
-    1, 3, 6, 10, 15, 21, 28, 36, 45, 55, 2, 14, 27, 41, 56, 8, 25, 43, 62,
-    18, 39, 61, 20, 44
-};
+static const unsigned keccakf_rotc[24]
+    = {1, 3, 6, 10, 15, 21, 28, 36, 45, 55, 2, 14, 27, 41, 56, 8, 25, 43, 62, 18, 39, 61, 20, 44};
 
-static const unsigned keccakf_piln[24] = {
-    10, 7, 11, 17, 18, 3, 5, 16, 8, 21, 24, 4, 15, 23, 19, 13, 12, 2, 20,
-    14, 22, 9, 6, 1
-};
+static const unsigned keccakf_piln[24]
+    = {10, 7, 11, 17, 18, 3, 5, 16, 8, 21, 24, 4, 15, 23, 19, 13, 12, 2, 20, 14, 22, 9, 6, 1};
 
-/* generally called after SHA3_KECCAK_SPONGE_WORDS-ctx->capacityWords words 
- * are XORed into the state s 
+/* generally called after SHA3_KECCAK_SPONGE_WORDS-ctx->capacityWords words
+ * are XORed into the state s
  */
-static void
-keccakf(uint64_t s[25])
+static void keccakf(uint64_t s[25])
 {
     int i, j, round;
     uint64_t t, bc[5];
 #define KECCAK_ROUNDS 24
 
-    for(round = 0; round < KECCAK_ROUNDS; round++) {
+    for (round = 0; round < KECCAK_ROUNDS; round++) {
 
         /* Theta */
-        for(i = 0; i < 5; i++)
+        for (i = 0; i < 5; i++)
             bc[i] = s[i] ^ s[i + 5] ^ s[i + 10] ^ s[i + 15] ^ s[i + 20];
 
-        for(i = 0; i < 5; i++) {
+        for (i = 0; i < 5; i++) {
             t = bc[(i + 4) % 5] ^ SHA3_ROTL64(bc[(i + 1) % 5], 1);
-            for(j = 0; j < 25; j += 5)
+            for (j = 0; j < 25; j += 5)
                 s[j + i] ^= t;
         }
 
         /* Rho Pi */
         t = s[1];
-        for(i = 0; i < 24; i++) {
+        for (i = 0; i < 24; i++) {
             j = keccakf_piln[i];
             bc[0] = s[j];
             s[j] = SHA3_ROTL64(t, keccakf_rotc[i]);
@@ -108,10 +101,10 @@ keccakf(uint64_t s[25])
         }
 
         /* Chi */
-        for(j = 0; j < 25; j += 5) {
-            for(i = 0; i < 5; i++)
+        for (j = 0; j < 25; j += 5) {
+            for (i = 0; i < 5; i++)
                 bc[i] = s[j + i];
-            for(i = 0; i < 5; i++)
+            for (i = 0; i < 5; i++)
                 s[j + i] ^= (~bc[(i + 1) % 5]) & bc[(i + 2) % 5];
         }
 
@@ -123,34 +116,30 @@ keccakf(uint64_t s[25])
 /* *************************** Public Inteface ************************ */
 
 /* For Init or Reset call these: */
-void
-sha3_Init256(void *priv)
+void sha3_Init256(void *priv)
 {
-    sha3_context *ctx = (sha3_context *) priv;
+    sha3_context *ctx = (sha3_context *)priv;
     memset(ctx, 0, sizeof(*ctx));
     ctx->capacityWords = 2 * 256 / (8 * sizeof(uint64_t));
 }
 
-void
-sha3_Init384(void *priv)
+void sha3_Init384(void *priv)
 {
-    sha3_context *ctx = (sha3_context *) priv;
+    sha3_context *ctx = (sha3_context *)priv;
     memset(ctx, 0, sizeof(*ctx));
     ctx->capacityWords = 2 * 384 / (8 * sizeof(uint64_t));
 }
 
-void
-sha3_Init512(void *priv)
+void sha3_Init512(void *priv)
 {
-    sha3_context *ctx = (sha3_context *) priv;
+    sha3_context *ctx = (sha3_context *)priv;
     memset(ctx, 0, sizeof(*ctx));
     ctx->capacityWords = 2 * 512 / (8 * sizeof(uint64_t));
 }
 
-void
-sha3_Update(void *priv, void const *bufIn, size_t len)
+void sha3_Update(void *priv, void const *bufIn, size_t len)
 {
-    sha3_context *ctx = (sha3_context *) priv;
+    sha3_context *ctx = (sha3_context *)priv;
 
     /* 0...7 -- how much is needed to have a word */
     unsigned old_tail = (8 - ctx->byteIndex) & 7;
@@ -166,31 +155,30 @@ sha3_Update(void *priv, void const *bufIn, size_t len)
     SHA3_ASSERT(ctx->byteIndex < 8);
     SHA3_ASSERT(ctx->wordIndex < sizeof(ctx->s) / sizeof(ctx->s[0]));
 
-    if(len < old_tail) {        /* have no complete word or haven't started 
-                                 * the word yet */
-        SHA3_TRACE("because %d<%d, store it and return", (unsigned)len,
-                (unsigned)old_tail);
+    if (len < old_tail) {
+        /* have no complete word or haven't started
+         * the word yet */
+        SHA3_TRACE("because %d<%d, store it and return", (unsigned)len, (unsigned)old_tail);
         /* endian-independent code follows: */
         while (len--)
-            ctx->saved |= (uint64_t) (*(buf++)) << ((ctx->byteIndex++) * 8);
+            ctx->saved |= (uint64_t)(*(buf++)) << ((ctx->byteIndex++) * 8);
         SHA3_ASSERT(ctx->byteIndex < 8);
         return;
     }
 
-    if(old_tail) {              /* will have one word to process */
+    if (old_tail) { /* will have one word to process */
         SHA3_TRACE("completing one word with %d bytes", (unsigned)old_tail);
         /* endian-independent code follows: */
         len -= old_tail;
         while (old_tail--)
-            ctx->saved |= (uint64_t) (*(buf++)) << ((ctx->byteIndex++) * 8);
+            ctx->saved |= (uint64_t)(*(buf++)) << ((ctx->byteIndex++) * 8);
 
         /* now ready to add saved to the sponge */
         ctx->s[ctx->wordIndex] ^= ctx->saved;
         SHA3_ASSERT(ctx->byteIndex == 8);
         ctx->byteIndex = 0;
         ctx->saved = 0;
-        if(++ctx->wordIndex ==
-                (SHA3_KECCAK_SPONGE_WORDS - ctx->capacityWords)) {
+        if (++ctx->wordIndex == (SHA3_KECCAK_SPONGE_WORDS - ctx->capacityWords)) {
             keccakf(ctx->s);
             ctx->wordIndex = 0;
         }
@@ -205,21 +193,16 @@ sha3_Update(void *priv, void const *bufIn, size_t len)
 
     SHA3_TRACE("have %d full words to process", (unsigned)words);
 
-    for(i = 0; i < words; i++, buf += sizeof(uint64_t)) {
-        const uint64_t t = (uint64_t) (buf[0]) |
-                ((uint64_t) (buf[1]) << 8 * 1) |
-                ((uint64_t) (buf[2]) << 8 * 2) |
-                ((uint64_t) (buf[3]) << 8 * 3) |
-                ((uint64_t) (buf[4]) << 8 * 4) |
-                ((uint64_t) (buf[5]) << 8 * 5) |
-                ((uint64_t) (buf[6]) << 8 * 6) |
-                ((uint64_t) (buf[7]) << 8 * 7);
-#if defined(__x86_64__ ) || defined(__i386__)
+    for (i = 0; i < words; i++, buf += sizeof(uint64_t)) {
+        const uint64_t t = (uint64_t)(buf[0]) | ((uint64_t)(buf[1]) << 8 * 1)
+            | ((uint64_t)(buf[2]) << 8 * 2) | ((uint64_t)(buf[3]) << 8 * 3)
+            | ((uint64_t)(buf[4]) << 8 * 4) | ((uint64_t)(buf[5]) << 8 * 5)
+            | ((uint64_t)(buf[6]) << 8 * 6) | ((uint64_t)(buf[7]) << 8 * 7);
+#if defined(__x86_64__) || defined(__i386__)
         SHA3_ASSERT(memcmp(&t, buf, 8) == 0);
 #endif
         ctx->s[ctx->wordIndex] ^= t;
-        if(++ctx->wordIndex ==
-                (SHA3_KECCAK_SPONGE_WORDS - ctx->capacityWords)) {
+        if (++ctx->wordIndex == (SHA3_KECCAK_SPONGE_WORDS - ctx->capacityWords)) {
             keccakf(ctx->s);
             ctx->wordIndex = 0;
         }
@@ -231,20 +214,19 @@ sha3_Update(void *priv, void const *bufIn, size_t len)
     SHA3_ASSERT(ctx->byteIndex == 0 && tail < 8);
     while (tail--) {
         SHA3_TRACE("Store byte %02x '%c'", *buf, *buf);
-        ctx->saved |= (uint64_t) (*(buf++)) << ((ctx->byteIndex++) * 8);
+        ctx->saved |= (uint64_t)(*(buf++)) << ((ctx->byteIndex++) * 8);
     }
     SHA3_ASSERT(ctx->byteIndex < 8);
     SHA3_TRACE("Have saved=0x%016" PRIx64 " at the end", ctx->saved);
 }
 
 /* This is simply the 'update' with the padding block.
- * The padding block is 0x01 || 0x00* || 0x80. First 0x01 and last 0x80 
+ * The padding block is 0x01 || 0x00* || 0x80. First 0x01 and last 0x80
  * bytes are always present, but they can be the same byte.
  */
-void const *
-sha3_Finalize(void *priv)
+void const *sha3_Finalize(void *priv)
 {
-    sha3_context *ctx = (sha3_context *) priv;
+    sha3_context *ctx = (sha3_context *)priv;
 
     SHA3_TRACE("called with %d bytes in the buffer", ctx->byteIndex);
 
@@ -255,18 +237,14 @@ sha3_Finalize(void *priv)
 
 #ifndef SHA3_USE_KECCAK
     /* SHA3 version */
-    ctx->s[ctx->wordIndex] ^=
-            (ctx->saved ^ ((uint64_t) ((uint64_t) (0x02 | (1 << 2)) <<
-                            ((ctx->byteIndex) * 8))));
+    ctx->s[ctx->wordIndex]
+        ^= (ctx->saved ^ ((uint64_t)((uint64_t)(0x02 | (1 << 2)) << ((ctx->byteIndex) * 8))));
 #else
     /* For testing the "pure" Keccak version */
-    ctx->s[ctx->wordIndex] ^=
-            (ctx->saved ^ ((uint64_t) ((uint64_t) 1 << (ctx->byteIndex *
-                                    8))));
+    ctx->s[ctx->wordIndex] ^= (ctx->saved ^ ((uint64_t)((uint64_t)1 << (ctx->byteIndex * 8))));
 #endif
 
-    ctx->s[SHA3_KECCAK_SPONGE_WORDS - ctx->capacityWords - 1] ^=
-            SHA3_CONST(0x8000000000000000UL);
+    ctx->s[SHA3_KECCAK_SPONGE_WORDS - ctx->capacityWords - 1] ^= SHA3_CONST(0x8000000000000000UL);
     keccakf(ctx->s);
 
     /* Return first bytes of the ctx->s. This conversion is not needed for
@@ -276,17 +254,17 @@ sha3_Finalize(void *priv)
      * #endif */
     {
         unsigned i;
-        for(i = 0; i < SHA3_KECCAK_SPONGE_WORDS; i++) {
-            const unsigned t1 = (uint32_t) ctx->s[i];
-            const unsigned t2 = (uint32_t) ((ctx->s[i] >> 16) >> 16);
-            ctx->sb[i * 8 + 0] = (uint8_t) (t1);
-            ctx->sb[i * 8 + 1] = (uint8_t) (t1 >> 8);
-            ctx->sb[i * 8 + 2] = (uint8_t) (t1 >> 16);
-            ctx->sb[i * 8 + 3] = (uint8_t) (t1 >> 24);
-            ctx->sb[i * 8 + 4] = (uint8_t) (t2);
-            ctx->sb[i * 8 + 5] = (uint8_t) (t2 >> 8);
-            ctx->sb[i * 8 + 6] = (uint8_t) (t2 >> 16);
-            ctx->sb[i * 8 + 7] = (uint8_t) (t2 >> 24);
+        for (i = 0; i < SHA3_KECCAK_SPONGE_WORDS; i++) {
+            const unsigned t1 = (uint32_t)ctx->s[i];
+            const unsigned t2 = (uint32_t)((ctx->s[i] >> 16) >> 16);
+            ctx->sb[i * 8 + 0] = (uint8_t)(t1);
+            ctx->sb[i * 8 + 1] = (uint8_t)(t1 >> 8);
+            ctx->sb[i * 8 + 2] = (uint8_t)(t1 >> 16);
+            ctx->sb[i * 8 + 3] = (uint8_t)(t1 >> 24);
+            ctx->sb[i * 8 + 4] = (uint8_t)(t2);
+            ctx->sb[i * 8 + 5] = (uint8_t)(t2 >> 8);
+            ctx->sb[i * 8 + 6] = (uint8_t)(t2 >> 16);
+            ctx->sb[i * 8 + 7] = (uint8_t)(t2 >> 24);
         }
     }
 

--- a/deps/sha3/sha3.h
+++ b/deps/sha3/sha3.h
@@ -1,42 +1,43 @@
 #ifndef SHA3_H
 #define SHA3_H
 
+#include <stddef.h>
+#include <stdint.h>
+
 /* -------------------------------------------------------------------------
- * Works when compiled for either 32-bit or 64-bit targets, optimized for 
+ * Works when compiled for either 32-bit or 64-bit targets, optimized for
  * 64 bit.
  *
- * Canonical implementation of Init/Update/Finalize for SHA-3 byte input. 
+ * Canonical implementation of Init/Update/Finalize for SHA-3 byte input.
  *
  * SHA3-256, SHA3-384, SHA-512 are implemented. SHA-224 can easily be added.
  *
  * Based on code from http://keccak.noekeon.org/ .
  *
- * I place the code that I wrote into public domain, free to use. 
+ * I place the code that I wrote into public domain, free to use.
  *
- * I would appreciate if you give credits to this work if you used it to 
+ * I would appreciate if you give credits to this work if you used it to
  * write or test * your code.
  *
  * Aug 2015. Andrey Jivsov. crypto@brainhub.org
  * ---------------------------------------------------------------------- */
 
 /* 'Words' here refers to uint64_t */
-#define SHA3_KECCAK_SPONGE_WORDS \
-	(((1600)/8/*bits to byte*/)/sizeof(uint64_t))
+#define SHA3_KECCAK_SPONGE_WORDS (((1600) / 8 /*bits to byte*/) / sizeof(uint64_t))
 typedef struct sha3_context_ {
-    uint64_t saved;             /* the portion of the input message that we
-                                 * didn't consume yet */
-    union {                     /* Keccak's state */
+    uint64_t saved; /* the portion of the input message that we
+                     * didn't consume yet */
+    union { /* Keccak's state */
         uint64_t s[SHA3_KECCAK_SPONGE_WORDS];
         uint8_t sb[SHA3_KECCAK_SPONGE_WORDS * 8];
     };
-    unsigned byteIndex;         /* 0..7--the next byte after the set one
-                                 * (starts from 0; 0--none are buffered) */
-    unsigned wordIndex;         /* 0..24--the next word to integrate input
-                                 * (starts from 0) */
-    unsigned capacityWords;     /* the double size of the hash output in
-                                 * words (e.g. 16 for Keccak 512) */
+    unsigned byteIndex; /* 0..7--the next byte after the set one
+                         * (starts from 0; 0--none are buffered) */
+    unsigned wordIndex; /* 0..24--the next word to integrate input
+                         * (starts from 0) */
+    unsigned capacityWords; /* the double size of the hash output in
+                             * words (e.g. 16 for Keccak 512) */
 } sha3_context;
-
 
 /* For Init or Reset call these: */
 void sha3_Init256(void *priv);

--- a/deps/uthash/uthash.h
+++ b/deps/uthash/uthash.h
@@ -26,40 +26,40 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #define UTHASH_VERSION 2.0.2
 
-#include <string.h>   /* memcmp, memset, strlen */
-#include <stddef.h>   /* ptrdiff_t */
-#include <stdlib.h>   /* exit */
+#include <stddef.h> /* ptrdiff_t */
+#include <stdlib.h> /* exit */
+#include <string.h> /* memcmp, memset, strlen */
 
 /* These macros use decltype or the earlier __typeof GNU extension.
    As decltype is only available in newer compilers (VS2010 or gcc 4.3+
    when compiling c++ source) this code uses whatever method is needed
    or, for VS2008 where neither is available, uses casting workarounds. */
 #if !defined(DECLTYPE) && !defined(NO_DECLTYPE)
-#if defined(_MSC_VER)   /* MS compiler */
-#if _MSC_VER >= 1600 && defined(__cplusplus)  /* VS2010 or newer in C++ mode */
+#if defined(_MSC_VER) /* MS compiler */
+#if _MSC_VER >= 1600 && defined(__cplusplus) /* VS2010 or newer in C++ mode */
 #define DECLTYPE(x) (decltype(x))
-#else                   /* VS2008 or older (or VS2010 in C mode) */
+#else /* VS2008 or older (or VS2010 in C mode) */
 #define NO_DECLTYPE
 #endif
 #elif defined(__BORLANDC__) || defined(__ICCARM__) || defined(__LCC__) || defined(__WATCOMC__)
 #define NO_DECLTYPE
-#else                   /* GNU, Sun and other compilers */
+#else /* GNU, Sun and other compilers */
 #define DECLTYPE(x) (__typeof(x))
 #endif
 #endif
 
 #ifdef NO_DECLTYPE
 #define DECLTYPE(x)
-#define DECLTYPE_ASSIGN(dst,src)                                                 \
-do {                                                                             \
-  char **_da_dst = (char**)(&(dst));                                             \
-  *_da_dst = (char*)(src);                                                       \
-} while (0)
+#define DECLTYPE_ASSIGN(dst, src)           \
+    do {                                    \
+        char **_da_dst = (char **)(&(dst)); \
+        *_da_dst = (char *)(src);           \
+    } while (0)
 #else
-#define DECLTYPE_ASSIGN(dst,src)                                                 \
-do {                                                                             \
-  (dst) = DECLTYPE(dst)(src);                                                    \
-} while (0)
+#define DECLTYPE_ASSIGN(dst, src)   \
+    do {                            \
+        (dst) = DECLTYPE(dst)(src); \
+    } while (0)
 #endif
 
 /* a number of the hash function use uint32_t which isn't defined on Pre VS2010 */
@@ -80,26 +80,26 @@ typedef unsigned char uint8_t;
 #endif
 
 #ifndef uthash_malloc
-#define uthash_malloc(sz) malloc(sz)      /* malloc fcn                      */
+#define uthash_malloc(sz) malloc(sz) /* malloc fcn                      */
 #endif
 #ifndef uthash_free
-#define uthash_free(ptr,sz) free(ptr)     /* free fcn                        */
+#define uthash_free(ptr, sz) free(ptr) /* free fcn                        */
 #endif
 #ifndef uthash_bzero
-#define uthash_bzero(a,n) memset(a,'\0',n)
+#define uthash_bzero(a, n) memset(a, '\0', n)
 #endif
 #ifndef uthash_memcmp
-#define uthash_memcmp(a,b,n) memcmp(a,b,n)
+#define uthash_memcmp(a, b, n) memcmp(a, b, n)
 #endif
 #ifndef uthash_strlen
 #define uthash_strlen(s) strlen(s)
 #endif
 
 #ifndef uthash_noexpand_fyi
-#define uthash_noexpand_fyi(tbl)          /* can be defined to log noexpand  */
+#define uthash_noexpand_fyi(tbl) /* can be defined to log noexpand  */
 #endif
 #ifndef uthash_expand_fyi
-#define uthash_expand_fyi(tbl)            /* can be defined to log expands   */
+#define uthash_expand_fyi(tbl) /* can be defined to log expands   */
 #endif
 
 #ifndef HASH_NONFATAL_OOM
@@ -110,17 +110,22 @@ typedef unsigned char uint8_t;
 /* malloc failures can be recovered from */
 
 #ifndef uthash_nonfatal_oom
-#define uthash_nonfatal_oom(obj) do {} while (0)    /* non-fatal OOM error */
+#define uthash_nonfatal_oom(obj) \
+    do {                         \
+    } while (0) /* non-fatal OOM error */
 #endif
 
-#define HASH_RECORD_OOM(oomed) do { (oomed) = 1; } while (0)
+#define HASH_RECORD_OOM(oomed) \
+    do {                       \
+        (oomed) = 1;           \
+    } while (0)
 #define IF_HASH_NONFATAL_OOM(x) x
 
 #else
 /* malloc failures result in lost memory, hash tables are unusable */
 
 #ifndef uthash_fatal
-#define uthash_fatal(msg) exit(-1)        /* fatal OOM error */
+#define uthash_fatal(msg) exit(-1) /* fatal OOM error */
 #endif
 
 #define HASH_RECORD_OOM(oomed) uthash_fatal("out of memory")
@@ -129,308 +134,313 @@ typedef unsigned char uint8_t;
 #endif
 
 /* initial number of buckets */
-#define HASH_INITIAL_NUM_BUCKETS 32U     /* initial number of buckets        */
+#define HASH_INITIAL_NUM_BUCKETS      32U /* initial number of buckets        */
 #define HASH_INITIAL_NUM_BUCKETS_LOG2 5U /* lg2 of initial number of buckets */
-#define HASH_BKT_CAPACITY_THRESH 10U     /* expand when bucket count reaches */
+#define HASH_BKT_CAPACITY_THRESH      10U /* expand when bucket count reaches */
 
 /* calculate the element whose hash handle address is hhp */
-#define ELMT_FROM_HH(tbl,hhp) ((void*)(((char*)(hhp)) - ((tbl)->hho)))
+#define ELMT_FROM_HH(tbl, hhp) ((void *)(((char *)(hhp)) - ((tbl)->hho)))
 /* calculate the hash handle from element address elp */
-#define HH_FROM_ELMT(tbl,elp) ((UT_hash_handle *)(((char*)(elp)) + ((tbl)->hho)))
+#define HH_FROM_ELMT(tbl, elp) ((UT_hash_handle *)(((char *)(elp)) + ((tbl)->hho)))
 
-#define HASH_ROLLBACK_BKT(hh, head, itemptrhh)                                   \
-do {                                                                             \
-  struct UT_hash_handle *_hd_hh_item = (itemptrhh);                              \
-  unsigned _hd_bkt;                                                              \
-  HASH_TO_BKT(_hd_hh_item->hashv, (head)->hh.tbl->num_buckets, _hd_bkt);         \
-  (head)->hh.tbl->buckets[_hd_bkt].count++;                                      \
-  _hd_hh_item->hh_next = NULL;                                                   \
-  _hd_hh_item->hh_prev = NULL;                                                   \
-} while (0)
+#define HASH_ROLLBACK_BKT(hh, head, itemptrhh)                                 \
+    do {                                                                       \
+        struct UT_hash_handle *_hd_hh_item = (itemptrhh);                      \
+        unsigned _hd_bkt;                                                      \
+        HASH_TO_BKT(_hd_hh_item->hashv, (head)->hh.tbl->num_buckets, _hd_bkt); \
+        (head)->hh.tbl->buckets[_hd_bkt].count++;                              \
+        _hd_hh_item->hh_next = NULL;                                           \
+        _hd_hh_item->hh_prev = NULL;                                           \
+    } while (0)
 
-#define HASH_VALUE(keyptr,keylen,hashv)                                          \
-do {                                                                             \
-  HASH_FCN(keyptr, keylen, hashv);                                               \
-} while (0)
+#define HASH_VALUE(keyptr, keylen, hashv) \
+    do {                                  \
+        HASH_FCN(keyptr, keylen, hashv);  \
+    } while (0)
 
-#define HASH_FIND_BYHASHVALUE(hh,head,keyptr,keylen,hashval,out)                 \
-do {                                                                             \
-  (out) = NULL;                                                                  \
-  if (head) {                                                                    \
-    unsigned _hf_bkt;                                                            \
-    HASH_TO_BKT(hashval, (head)->hh.tbl->num_buckets, _hf_bkt);                  \
-    if (HASH_BLOOM_TEST((head)->hh.tbl, hashval) != 0) {                         \
-      HASH_FIND_IN_BKT((head)->hh.tbl, hh, (head)->hh.tbl->buckets[ _hf_bkt ], keyptr, keylen, hashval, out); \
-    }                                                                            \
-  }                                                                              \
-} while (0)
+#define HASH_FIND_BYHASHVALUE(hh, head, keyptr, keylen, hashval, out)                          \
+    do {                                                                                       \
+        (out) = NULL;                                                                          \
+        if (head) {                                                                            \
+            unsigned _hf_bkt;                                                                  \
+            HASH_TO_BKT(hashval, (head)->hh.tbl->num_buckets, _hf_bkt);                        \
+            if (HASH_BLOOM_TEST((head)->hh.tbl, hashval) != 0) {                               \
+                HASH_FIND_IN_BKT((head)->hh.tbl, hh, (head)->hh.tbl->buckets[_hf_bkt], keyptr, \
+                    keylen, hashval, out);                                                     \
+            }                                                                                  \
+        }                                                                                      \
+    } while (0)
 
-#define HASH_FIND(hh,head,keyptr,keylen,out)                                     \
-do {                                                                             \
-  unsigned _hf_hashv;                                                            \
-  HASH_VALUE(keyptr, keylen, _hf_hashv);                                         \
-  HASH_FIND_BYHASHVALUE(hh, head, keyptr, keylen, _hf_hashv, out);               \
-} while (0)
+#define HASH_FIND(hh, head, keyptr, keylen, out)                         \
+    do {                                                                 \
+        unsigned _hf_hashv;                                              \
+        HASH_VALUE(keyptr, keylen, _hf_hashv);                           \
+        HASH_FIND_BYHASHVALUE(hh, head, keyptr, keylen, _hf_hashv, out); \
+    } while (0)
 
 #ifdef HASH_BLOOM
 #define HASH_BLOOM_BITLEN (1UL << HASH_BLOOM)
-#define HASH_BLOOM_BYTELEN (HASH_BLOOM_BITLEN/8UL) + (((HASH_BLOOM_BITLEN%8UL)!=0UL) ? 1UL : 0UL)
-#define HASH_BLOOM_MAKE(tbl,oomed)                                               \
-do {                                                                             \
-  (tbl)->bloom_nbits = HASH_BLOOM;                                               \
-  (tbl)->bloom_bv = (uint8_t*)uthash_malloc(HASH_BLOOM_BYTELEN);                 \
-  if (!(tbl)->bloom_bv) {                                                        \
-    HASH_RECORD_OOM(oomed);                                                      \
-  } else {                                                                       \
-    uthash_bzero((tbl)->bloom_bv, HASH_BLOOM_BYTELEN);                           \
-    (tbl)->bloom_sig = HASH_BLOOM_SIGNATURE;                                     \
-  }                                                                              \
-} while (0)
+#define HASH_BLOOM_BYTELEN \
+    (HASH_BLOOM_BITLEN / 8UL) + (((HASH_BLOOM_BITLEN % 8UL) != 0UL) ? 1UL : 0UL)
+#define HASH_BLOOM_MAKE(tbl, oomed)                                     \
+    do {                                                                \
+        (tbl)->bloom_nbits = HASH_BLOOM;                                \
+        (tbl)->bloom_bv = (uint8_t *)uthash_malloc(HASH_BLOOM_BYTELEN); \
+        if (!(tbl)->bloom_bv) {                                         \
+            HASH_RECORD_OOM(oomed);                                     \
+        } else {                                                        \
+            uthash_bzero((tbl)->bloom_bv, HASH_BLOOM_BYTELEN);          \
+            (tbl)->bloom_sig = HASH_BLOOM_SIGNATURE;                    \
+        }                                                               \
+    } while (0)
 
-#define HASH_BLOOM_FREE(tbl)                                                     \
-do {                                                                             \
-  uthash_free((tbl)->bloom_bv, HASH_BLOOM_BYTELEN);                              \
-} while (0)
+#define HASH_BLOOM_FREE(tbl)                              \
+    do {                                                  \
+        uthash_free((tbl)->bloom_bv, HASH_BLOOM_BYTELEN); \
+    } while (0)
 
-#define HASH_BLOOM_BITSET(bv,idx) (bv[(idx)/8U] |= (1U << ((idx)%8U)))
-#define HASH_BLOOM_BITTEST(bv,idx) (bv[(idx)/8U] & (1U << ((idx)%8U)))
+#define HASH_BLOOM_BITSET(bv, idx)  (bv[(idx) / 8U] |= (1U << ((idx) % 8U)))
+#define HASH_BLOOM_BITTEST(bv, idx) (bv[(idx) / 8U] & (1U << ((idx) % 8U)))
 
-#define HASH_BLOOM_ADD(tbl,hashv)                                                \
-  HASH_BLOOM_BITSET((tbl)->bloom_bv, ((hashv) & (uint32_t)((1UL << (tbl)->bloom_nbits) - 1U)))
+#define HASH_BLOOM_ADD(tbl, hashv) \
+    HASH_BLOOM_BITSET((tbl)->bloom_bv, ((hashv) & (uint32_t)((1UL << (tbl)->bloom_nbits) - 1U)))
 
-#define HASH_BLOOM_TEST(tbl,hashv)                                               \
-  HASH_BLOOM_BITTEST((tbl)->bloom_bv, ((hashv) & (uint32_t)((1UL << (tbl)->bloom_nbits) - 1U)))
+#define HASH_BLOOM_TEST(tbl, hashv) \
+    HASH_BLOOM_BITTEST((tbl)->bloom_bv, ((hashv) & (uint32_t)((1UL << (tbl)->bloom_nbits) - 1U)))
 
 #else
-#define HASH_BLOOM_MAKE(tbl,oomed)
+#define HASH_BLOOM_MAKE(tbl, oomed)
 #define HASH_BLOOM_FREE(tbl)
-#define HASH_BLOOM_ADD(tbl,hashv)
-#define HASH_BLOOM_TEST(tbl,hashv) (1)
-#define HASH_BLOOM_BYTELEN 0U
+#define HASH_BLOOM_ADD(tbl, hashv)
+#define HASH_BLOOM_TEST(tbl, hashv) (1)
+#define HASH_BLOOM_BYTELEN          0U
 #endif
 
-#define HASH_MAKE_TABLE(hh,head,oomed)                                           \
-do {                                                                             \
-  (head)->hh.tbl = (UT_hash_table*)uthash_malloc(sizeof(UT_hash_table));         \
-  if (!(head)->hh.tbl) {                                                         \
-    HASH_RECORD_OOM(oomed);                                                      \
-  } else {                                                                       \
-    uthash_bzero((head)->hh.tbl, sizeof(UT_hash_table));                         \
-    (head)->hh.tbl->tail = &((head)->hh);                                        \
-    (head)->hh.tbl->num_buckets = HASH_INITIAL_NUM_BUCKETS;                      \
-    (head)->hh.tbl->log2_num_buckets = HASH_INITIAL_NUM_BUCKETS_LOG2;            \
-    (head)->hh.tbl->hho = (char*)(&(head)->hh) - (char*)(head);                  \
-    (head)->hh.tbl->buckets = (UT_hash_bucket*)uthash_malloc(                    \
-        HASH_INITIAL_NUM_BUCKETS * sizeof(struct UT_hash_bucket));               \
-    (head)->hh.tbl->signature = HASH_SIGNATURE;                                  \
-    if (!(head)->hh.tbl->buckets) {                                              \
-      HASH_RECORD_OOM(oomed);                                                    \
-      uthash_free((head)->hh.tbl, sizeof(UT_hash_table));                        \
-    } else {                                                                     \
-      uthash_bzero((head)->hh.tbl->buckets,                                      \
-          HASH_INITIAL_NUM_BUCKETS * sizeof(struct UT_hash_bucket));             \
-      HASH_BLOOM_MAKE((head)->hh.tbl, oomed);                                    \
-      IF_HASH_NONFATAL_OOM(                                                      \
-        if (oomed) {                                                             \
-          uthash_free((head)->hh.tbl->buckets,                                   \
-              HASH_INITIAL_NUM_BUCKETS*sizeof(struct UT_hash_bucket));           \
-          uthash_free((head)->hh.tbl, sizeof(UT_hash_table));                    \
-        }                                                                        \
-      )                                                                          \
-    }                                                                            \
-  }                                                                              \
-} while (0)
+#define HASH_MAKE_TABLE(hh, head, oomed)                                           \
+    do {                                                                           \
+        (head)->hh.tbl = (UT_hash_table *)uthash_malloc(sizeof(UT_hash_table));    \
+        if (!(head)->hh.tbl) {                                                     \
+            HASH_RECORD_OOM(oomed);                                                \
+        } else {                                                                   \
+            uthash_bzero((head)->hh.tbl, sizeof(UT_hash_table));                   \
+            (head)->hh.tbl->tail = &((head)->hh);                                  \
+            (head)->hh.tbl->num_buckets = HASH_INITIAL_NUM_BUCKETS;                \
+            (head)->hh.tbl->log2_num_buckets = HASH_INITIAL_NUM_BUCKETS_LOG2;      \
+            (head)->hh.tbl->hho = (char *)(&(head)->hh) - (char *)(head);          \
+            (head)->hh.tbl->buckets = (UT_hash_bucket *)uthash_malloc(             \
+                HASH_INITIAL_NUM_BUCKETS * sizeof(struct UT_hash_bucket));         \
+            (head)->hh.tbl->signature = HASH_SIGNATURE;                            \
+            if (!(head)->hh.tbl->buckets) {                                        \
+                HASH_RECORD_OOM(oomed);                                            \
+                uthash_free((head)->hh.tbl, sizeof(UT_hash_table));                \
+            } else {                                                               \
+                uthash_bzero((head)->hh.tbl->buckets,                              \
+                    HASH_INITIAL_NUM_BUCKETS * sizeof(struct UT_hash_bucket));     \
+                HASH_BLOOM_MAKE((head)->hh.tbl, oomed);                            \
+                IF_HASH_NONFATAL_OOM(if (oomed) {                                  \
+                    uthash_free((head)->hh.tbl->buckets,                           \
+                        HASH_INITIAL_NUM_BUCKETS * sizeof(struct UT_hash_bucket)); \
+                    uthash_free((head)->hh.tbl, sizeof(UT_hash_table));            \
+                })                                                                 \
+            }                                                                      \
+        }                                                                          \
+    } while (0)
 
-#define HASH_REPLACE_BYHASHVALUE_INORDER(hh,head,fieldname,keylen_in,hashval,add,replaced,cmpfcn) \
-do {                                                                             \
-  (replaced) = NULL;                                                             \
-  HASH_FIND_BYHASHVALUE(hh, head, &((add)->fieldname), keylen_in, hashval, replaced); \
-  if (replaced) {                                                                \
-    HASH_DELETE(hh, head, replaced);                                             \
-  }                                                                              \
-  HASH_ADD_KEYPTR_BYHASHVALUE_INORDER(hh, head, &((add)->fieldname), keylen_in, hashval, add, cmpfcn); \
-} while (0)
+#define HASH_REPLACE_BYHASHVALUE_INORDER(                                                   \
+    hh, head, fieldname, keylen_in, hashval, add, replaced, cmpfcn)                         \
+    do {                                                                                    \
+        (replaced) = NULL;                                                                  \
+        HASH_FIND_BYHASHVALUE(hh, head, &((add)->fieldname), keylen_in, hashval, replaced); \
+        if (replaced) {                                                                     \
+            HASH_DELETE(hh, head, replaced);                                                \
+        }                                                                                   \
+        HASH_ADD_KEYPTR_BYHASHVALUE_INORDER(                                                \
+            hh, head, &((add)->fieldname), keylen_in, hashval, add, cmpfcn);                \
+    } while (0)
 
-#define HASH_REPLACE_BYHASHVALUE(hh,head,fieldname,keylen_in,hashval,add,replaced) \
-do {                                                                             \
-  (replaced) = NULL;                                                             \
-  HASH_FIND_BYHASHVALUE(hh, head, &((add)->fieldname), keylen_in, hashval, replaced); \
-  if (replaced) {                                                                \
-    HASH_DELETE(hh, head, replaced);                                             \
-  }                                                                              \
-  HASH_ADD_KEYPTR_BYHASHVALUE(hh, head, &((add)->fieldname), keylen_in, hashval, add); \
-} while (0)
+#define HASH_REPLACE_BYHASHVALUE(hh, head, fieldname, keylen_in, hashval, add, replaced)     \
+    do {                                                                                     \
+        (replaced) = NULL;                                                                   \
+        HASH_FIND_BYHASHVALUE(hh, head, &((add)->fieldname), keylen_in, hashval, replaced);  \
+        if (replaced) {                                                                      \
+            HASH_DELETE(hh, head, replaced);                                                 \
+        }                                                                                    \
+        HASH_ADD_KEYPTR_BYHASHVALUE(hh, head, &((add)->fieldname), keylen_in, hashval, add); \
+    } while (0)
 
-#define HASH_REPLACE(hh,head,fieldname,keylen_in,add,replaced)                   \
-do {                                                                             \
-  unsigned _hr_hashv;                                                            \
-  HASH_VALUE(&((add)->fieldname), keylen_in, _hr_hashv);                         \
-  HASH_REPLACE_BYHASHVALUE(hh, head, fieldname, keylen_in, _hr_hashv, add, replaced); \
-} while (0)
+#define HASH_REPLACE(hh, head, fieldname, keylen_in, add, replaced)                         \
+    do {                                                                                    \
+        unsigned _hr_hashv;                                                                 \
+        HASH_VALUE(&((add)->fieldname), keylen_in, _hr_hashv);                              \
+        HASH_REPLACE_BYHASHVALUE(hh, head, fieldname, keylen_in, _hr_hashv, add, replaced); \
+    } while (0)
 
-#define HASH_REPLACE_INORDER(hh,head,fieldname,keylen_in,add,replaced,cmpfcn)    \
-do {                                                                             \
-  unsigned _hr_hashv;                                                            \
-  HASH_VALUE(&((add)->fieldname), keylen_in, _hr_hashv);                         \
-  HASH_REPLACE_BYHASHVALUE_INORDER(hh, head, fieldname, keylen_in, _hr_hashv, add, replaced, cmpfcn); \
-} while (0)
+#define HASH_REPLACE_INORDER(hh, head, fieldname, keylen_in, add, replaced, cmpfcn) \
+    do {                                                                            \
+        unsigned _hr_hashv;                                                         \
+        HASH_VALUE(&((add)->fieldname), keylen_in, _hr_hashv);                      \
+        HASH_REPLACE_BYHASHVALUE_INORDER(                                           \
+            hh, head, fieldname, keylen_in, _hr_hashv, add, replaced, cmpfcn);      \
+    } while (0)
 
-#define HASH_APPEND_LIST(hh, head, add)                                          \
-do {                                                                             \
-  (add)->hh.next = NULL;                                                         \
-  (add)->hh.prev = ELMT_FROM_HH((head)->hh.tbl, (head)->hh.tbl->tail);           \
-  (head)->hh.tbl->tail->next = (add);                                            \
-  (head)->hh.tbl->tail = &((add)->hh);                                           \
-} while (0)
+#define HASH_APPEND_LIST(hh, head, add)                                      \
+    do {                                                                     \
+        (add)->hh.next = NULL;                                               \
+        (add)->hh.prev = ELMT_FROM_HH((head)->hh.tbl, (head)->hh.tbl->tail); \
+        (head)->hh.tbl->tail->next = (add);                                  \
+        (head)->hh.tbl->tail = &((add)->hh);                                 \
+    } while (0)
 
-#define HASH_AKBI_INNER_LOOP(hh,head,add,cmpfcn)                                 \
-do {                                                                             \
-  do {                                                                           \
-    if (cmpfcn(DECLTYPE(head)(_hs_iter), add) > 0) {                             \
-      break;                                                                     \
-    }                                                                            \
-  } while ((_hs_iter = HH_FROM_ELMT((head)->hh.tbl, _hs_iter)->next));           \
-} while (0)
+#define HASH_AKBI_INNER_LOOP(hh, head, add, cmpfcn)                          \
+    do {                                                                     \
+        do {                                                                 \
+            if (cmpfcn(DECLTYPE(head)(_hs_iter), add) > 0) {                 \
+                break;                                                       \
+            }                                                                \
+        } while ((_hs_iter = HH_FROM_ELMT((head)->hh.tbl, _hs_iter)->next)); \
+    } while (0)
 
 #ifdef NO_DECLTYPE
 #undef HASH_AKBI_INNER_LOOP
-#define HASH_AKBI_INNER_LOOP(hh,head,add,cmpfcn)                                 \
-do {                                                                             \
-  char *_hs_saved_head = (char*)(head);                                          \
-  do {                                                                           \
-    DECLTYPE_ASSIGN(head, _hs_iter);                                             \
-    if (cmpfcn(head, add) > 0) {                                                 \
-      DECLTYPE_ASSIGN(head, _hs_saved_head);                                     \
-      break;                                                                     \
-    }                                                                            \
-    DECLTYPE_ASSIGN(head, _hs_saved_head);                                       \
-  } while ((_hs_iter = HH_FROM_ELMT((head)->hh.tbl, _hs_iter)->next));           \
-} while (0)
+#define HASH_AKBI_INNER_LOOP(hh, head, add, cmpfcn)                          \
+    do {                                                                     \
+        char *_hs_saved_head = (char *)(head);                               \
+        do {                                                                 \
+            DECLTYPE_ASSIGN(head, _hs_iter);                                 \
+            if (cmpfcn(head, add) > 0) {                                     \
+                DECLTYPE_ASSIGN(head, _hs_saved_head);                       \
+                break;                                                       \
+            }                                                                \
+            DECLTYPE_ASSIGN(head, _hs_saved_head);                           \
+        } while ((_hs_iter = HH_FROM_ELMT((head)->hh.tbl, _hs_iter)->next)); \
+    } while (0)
 #endif
 
 #if HASH_NONFATAL_OOM
 
-#define HASH_ADD_TO_TABLE(hh,head,keyptr,keylen_in,hashval,add,oomed)            \
-do {                                                                             \
-  if (!(oomed)) {                                                                \
-    unsigned _ha_bkt;                                                            \
-    (head)->hh.tbl->num_items++;                                                 \
-    HASH_TO_BKT(hashval, (head)->hh.tbl->num_buckets, _ha_bkt);                  \
-    HASH_ADD_TO_BKT((head)->hh.tbl->buckets[_ha_bkt], hh, &(add)->hh, oomed);    \
-    if (oomed) {                                                                 \
-      HASH_ROLLBACK_BKT(hh, head, &(add)->hh);                                   \
-      HASH_DELETE_HH(hh, head, &(add)->hh);                                      \
-      (add)->hh.tbl = NULL;                                                      \
-      uthash_nonfatal_oom(add);                                                  \
-    } else {                                                                     \
-      HASH_BLOOM_ADD((head)->hh.tbl, hashval);                                   \
-      HASH_EMIT_KEY(hh, head, keyptr, keylen_in);                                \
-    }                                                                            \
-  } else {                                                                       \
-    (add)->hh.tbl = NULL;                                                        \
-    uthash_nonfatal_oom(add);                                                    \
-  }                                                                              \
-} while (0)
+#define HASH_ADD_TO_TABLE(hh, head, keyptr, keylen_in, hashval, add, oomed)           \
+    do {                                                                              \
+        if (!(oomed)) {                                                               \
+            unsigned _ha_bkt;                                                         \
+            (head)->hh.tbl->num_items++;                                              \
+            HASH_TO_BKT(hashval, (head)->hh.tbl->num_buckets, _ha_bkt);               \
+            HASH_ADD_TO_BKT((head)->hh.tbl->buckets[_ha_bkt], hh, &(add)->hh, oomed); \
+            if (oomed) {                                                              \
+                HASH_ROLLBACK_BKT(hh, head, &(add)->hh);                              \
+                HASH_DELETE_HH(hh, head, &(add)->hh);                                 \
+                (add)->hh.tbl = NULL;                                                 \
+                uthash_nonfatal_oom(add);                                             \
+            } else {                                                                  \
+                HASH_BLOOM_ADD((head)->hh.tbl, hashval);                              \
+                HASH_EMIT_KEY(hh, head, keyptr, keylen_in);                           \
+            }                                                                         \
+        } else {                                                                      \
+            (add)->hh.tbl = NULL;                                                     \
+            uthash_nonfatal_oom(add);                                                 \
+        }                                                                             \
+    } while (0)
 
 #else
 
-#define HASH_ADD_TO_TABLE(hh,head,keyptr,keylen_in,hashval,add,oomed)            \
-do {                                                                             \
-  unsigned _ha_bkt;                                                              \
-  (head)->hh.tbl->num_items++;                                                   \
-  HASH_TO_BKT(hashval, (head)->hh.tbl->num_buckets, _ha_bkt);                    \
-  HASH_ADD_TO_BKT((head)->hh.tbl->buckets[_ha_bkt], hh, &(add)->hh, oomed);      \
-  HASH_BLOOM_ADD((head)->hh.tbl, hashval);                                       \
-  HASH_EMIT_KEY(hh, head, keyptr, keylen_in);                                    \
-} while (0)
+#define HASH_ADD_TO_TABLE(hh, head, keyptr, keylen_in, hashval, add, oomed)       \
+    do {                                                                          \
+        unsigned _ha_bkt;                                                         \
+        (head)->hh.tbl->num_items++;                                              \
+        HASH_TO_BKT(hashval, (head)->hh.tbl->num_buckets, _ha_bkt);               \
+        HASH_ADD_TO_BKT((head)->hh.tbl->buckets[_ha_bkt], hh, &(add)->hh, oomed); \
+        HASH_BLOOM_ADD((head)->hh.tbl, hashval);                                  \
+        HASH_EMIT_KEY(hh, head, keyptr, keylen_in);                               \
+    } while (0)
 
 #endif
 
+#define HASH_ADD_KEYPTR_BYHASHVALUE_INORDER(hh, head, keyptr, keylen_in, hashval, add, cmpfcn) \
+    do {                                                                                       \
+        IF_HASH_NONFATAL_OOM(int _ha_oomed = 0;)                                               \
+        (add)->hh.hashv = (hashval);                                                           \
+        (add)->hh.key = (char *)(keyptr);                                                      \
+        (add)->hh.keylen = (unsigned)(keylen_in);                                              \
+        if (!(head)) {                                                                         \
+            (add)->hh.next = NULL;                                                             \
+            (add)->hh.prev = NULL;                                                             \
+            HASH_MAKE_TABLE(hh, add, _ha_oomed);                                               \
+            IF_HASH_NONFATAL_OOM(if (!_ha_oomed) { )                                    \
+      (head) = (add);                                                                          \
+    IF_HASH_NONFATAL_OOM(                                                                      \
+            })                                                                                 \
+        } else {                                                                               \
+            void *_hs_iter = (head);                                                           \
+            (add)->hh.tbl = (head)->hh.tbl;                                                    \
+            HASH_AKBI_INNER_LOOP(hh, head, add, cmpfcn);                                       \
+            if (_hs_iter) {                                                                    \
+                (add)->hh.next = _hs_iter;                                                     \
+                if (((add)->hh.prev = HH_FROM_ELMT((head)->hh.tbl, _hs_iter)->prev)) {         \
+                    HH_FROM_ELMT((head)->hh.tbl, (add)->hh.prev)->next = (add);                \
+                } else {                                                                       \
+                    (head) = (add);                                                            \
+                }                                                                              \
+                HH_FROM_ELMT((head)->hh.tbl, _hs_iter)->prev = (add);                          \
+            } else {                                                                           \
+                HASH_APPEND_LIST(hh, head, add);                                               \
+            }                                                                                  \
+        }                                                                                      \
+        HASH_ADD_TO_TABLE(hh, head, keyptr, keylen_in, hashval, add, _ha_oomed);               \
+        HASH_FSCK(hh, head, "HASH_ADD_KEYPTR_BYHASHVALUE_INORDER");                            \
+    } while (0)
 
-#define HASH_ADD_KEYPTR_BYHASHVALUE_INORDER(hh,head,keyptr,keylen_in,hashval,add,cmpfcn) \
-do {                                                                             \
-  IF_HASH_NONFATAL_OOM( int _ha_oomed = 0; )                                     \
-  (add)->hh.hashv = (hashval);                                                   \
-  (add)->hh.key = (char*) (keyptr);                                              \
-  (add)->hh.keylen = (unsigned) (keylen_in);                                     \
-  if (!(head)) {                                                                 \
-    (add)->hh.next = NULL;                                                       \
-    (add)->hh.prev = NULL;                                                       \
-    HASH_MAKE_TABLE(hh, add, _ha_oomed);                                         \
-    IF_HASH_NONFATAL_OOM( if (!_ha_oomed) { )                                    \
+#define HASH_ADD_KEYPTR_INORDER(hh, head, keyptr, keylen_in, add, cmpfcn)                         \
+    do {                                                                                          \
+        unsigned _hs_hashv;                                                                       \
+        HASH_VALUE(keyptr, keylen_in, _hs_hashv);                                                 \
+        HASH_ADD_KEYPTR_BYHASHVALUE_INORDER(hh, head, keyptr, keylen_in, _hs_hashv, add, cmpfcn); \
+    } while (0)
+
+#define HASH_ADD_BYHASHVALUE_INORDER(hh, head, fieldname, keylen_in, hashval, add, cmpfcn) \
+    HASH_ADD_KEYPTR_BYHASHVALUE_INORDER(                                                   \
+        hh, head, &((add)->fieldname), keylen_in, hashval, add, cmpfcn)
+
+#define HASH_ADD_INORDER(hh, head, fieldname, keylen_in, add, cmpfcn) \
+    HASH_ADD_KEYPTR_INORDER(hh, head, &((add)->fieldname), keylen_in, add, cmpfcn)
+
+#define HASH_ADD_KEYPTR_BYHASHVALUE(hh, head, keyptr, keylen_in, hashval, add)   \
+    do {                                                                         \
+        IF_HASH_NONFATAL_OOM(int _ha_oomed = 0;)                                 \
+        (add)->hh.hashv = (hashval);                                             \
+        (add)->hh.key = (char *)(keyptr);                                        \
+        (add)->hh.keylen = (unsigned)(keylen_in);                                \
+        if (!(head)) {                                                           \
+            (add)->hh.next = NULL;                                               \
+            (add)->hh.prev = NULL;                                               \
+            HASH_MAKE_TABLE(hh, add, _ha_oomed);                                 \
+            IF_HASH_NONFATAL_OOM(if (!_ha_oomed) { )                                    \
       (head) = (add);                                                            \
-    IF_HASH_NONFATAL_OOM( } )                                                    \
-  } else {                                                                       \
-    void *_hs_iter = (head);                                                     \
-    (add)->hh.tbl = (head)->hh.tbl;                                              \
-    HASH_AKBI_INNER_LOOP(hh, head, add, cmpfcn);                                 \
-    if (_hs_iter) {                                                              \
-      (add)->hh.next = _hs_iter;                                                 \
-      if (((add)->hh.prev = HH_FROM_ELMT((head)->hh.tbl, _hs_iter)->prev)) {     \
-        HH_FROM_ELMT((head)->hh.tbl, (add)->hh.prev)->next = (add);              \
-      } else {                                                                   \
-        (head) = (add);                                                          \
-      }                                                                          \
-      HH_FROM_ELMT((head)->hh.tbl, _hs_iter)->prev = (add);                      \
-    } else {                                                                     \
-      HASH_APPEND_LIST(hh, head, add);                                           \
-    }                                                                            \
-  }                                                                              \
-  HASH_ADD_TO_TABLE(hh, head, keyptr, keylen_in, hashval, add, _ha_oomed);       \
-  HASH_FSCK(hh, head, "HASH_ADD_KEYPTR_BYHASHVALUE_INORDER");                    \
-} while (0)
+    IF_HASH_NONFATAL_OOM(                                                        \
+            })                                                                   \
+        } else {                                                                 \
+            (add)->hh.tbl = (head)->hh.tbl;                                      \
+            HASH_APPEND_LIST(hh, head, add);                                     \
+        }                                                                        \
+        HASH_ADD_TO_TABLE(hh, head, keyptr, keylen_in, hashval, add, _ha_oomed); \
+        HASH_FSCK(hh, head, "HASH_ADD_KEYPTR_BYHASHVALUE");                      \
+    } while (0)
 
-#define HASH_ADD_KEYPTR_INORDER(hh,head,keyptr,keylen_in,add,cmpfcn)             \
-do {                                                                             \
-  unsigned _hs_hashv;                                                            \
-  HASH_VALUE(keyptr, keylen_in, _hs_hashv);                                      \
-  HASH_ADD_KEYPTR_BYHASHVALUE_INORDER(hh, head, keyptr, keylen_in, _hs_hashv, add, cmpfcn); \
-} while (0)
+#define HASH_ADD_KEYPTR(hh, head, keyptr, keylen_in, add)                         \
+    do {                                                                          \
+        unsigned _ha_hashv;                                                       \
+        HASH_VALUE(keyptr, keylen_in, _ha_hashv);                                 \
+        HASH_ADD_KEYPTR_BYHASHVALUE(hh, head, keyptr, keylen_in, _ha_hashv, add); \
+    } while (0)
 
-#define HASH_ADD_BYHASHVALUE_INORDER(hh,head,fieldname,keylen_in,hashval,add,cmpfcn) \
-  HASH_ADD_KEYPTR_BYHASHVALUE_INORDER(hh, head, &((add)->fieldname), keylen_in, hashval, add, cmpfcn)
+#define HASH_ADD_BYHASHVALUE(hh, head, fieldname, keylen_in, hashval, add) \
+    HASH_ADD_KEYPTR_BYHASHVALUE(hh, head, &((add)->fieldname), keylen_in, hashval, add)
 
-#define HASH_ADD_INORDER(hh,head,fieldname,keylen_in,add,cmpfcn)                 \
-  HASH_ADD_KEYPTR_INORDER(hh, head, &((add)->fieldname), keylen_in, add, cmpfcn)
+#define HASH_ADD(hh, head, fieldname, keylen_in, add) \
+    HASH_ADD_KEYPTR(hh, head, &((add)->fieldname), keylen_in, add)
 
-#define HASH_ADD_KEYPTR_BYHASHVALUE(hh,head,keyptr,keylen_in,hashval,add)        \
-do {                                                                             \
-  IF_HASH_NONFATAL_OOM( int _ha_oomed = 0; )                                     \
-  (add)->hh.hashv = (hashval);                                                   \
-  (add)->hh.key = (char*) (keyptr);                                              \
-  (add)->hh.keylen = (unsigned) (keylen_in);                                     \
-  if (!(head)) {                                                                 \
-    (add)->hh.next = NULL;                                                       \
-    (add)->hh.prev = NULL;                                                       \
-    HASH_MAKE_TABLE(hh, add, _ha_oomed);                                         \
-    IF_HASH_NONFATAL_OOM( if (!_ha_oomed) { )                                    \
-      (head) = (add);                                                            \
-    IF_HASH_NONFATAL_OOM( } )                                                    \
-  } else {                                                                       \
-    (add)->hh.tbl = (head)->hh.tbl;                                              \
-    HASH_APPEND_LIST(hh, head, add);                                             \
-  }                                                                              \
-  HASH_ADD_TO_TABLE(hh, head, keyptr, keylen_in, hashval, add, _ha_oomed);       \
-  HASH_FSCK(hh, head, "HASH_ADD_KEYPTR_BYHASHVALUE");                            \
-} while (0)
-
-#define HASH_ADD_KEYPTR(hh,head,keyptr,keylen_in,add)                            \
-do {                                                                             \
-  unsigned _ha_hashv;                                                            \
-  HASH_VALUE(keyptr, keylen_in, _ha_hashv);                                      \
-  HASH_ADD_KEYPTR_BYHASHVALUE(hh, head, keyptr, keylen_in, _ha_hashv, add);      \
-} while (0)
-
-#define HASH_ADD_BYHASHVALUE(hh,head,fieldname,keylen_in,hashval,add)            \
-  HASH_ADD_KEYPTR_BYHASHVALUE(hh, head, &((add)->fieldname), keylen_in, hashval, add)
-
-#define HASH_ADD(hh,head,fieldname,keylen_in,add)                                \
-  HASH_ADD_KEYPTR(hh, head, &((add)->fieldname), keylen_in, add)
-
-#define HASH_TO_BKT(hashv,num_bkts,bkt)                                          \
-do {                                                                             \
-  bkt = ((hashv) & ((num_bkts) - 1U));                                           \
-} while (0)
+#define HASH_TO_BKT(hashv, num_bkts, bkt)  \
+    do {                                   \
+        bkt = ((hashv) & ((num_bkts)-1U)); \
+    } while (0)
 
 /* delete "delptr" from the hash table.
  * "the usual" patch-up process for the app-order doubly-linked-list.
@@ -444,138 +454,136 @@ do {                                                                            
  * copy the deletee pointer, then the latter references are via that
  * scratch pointer rather than through the repointed (users) symbol.
  */
-#define HASH_DELETE(hh,head,delptr)                                              \
-    HASH_DELETE_HH(hh, head, &(delptr)->hh)
+#define HASH_DELETE(hh, head, delptr) HASH_DELETE_HH(hh, head, &(delptr)->hh)
 
-#define HASH_DELETE_HH(hh,head,delptrhh)                                         \
-do {                                                                             \
-  struct UT_hash_handle *_hd_hh_del = (delptrhh);                                \
-  if ((_hd_hh_del->prev == NULL) && (_hd_hh_del->next == NULL)) {                \
-    HASH_BLOOM_FREE((head)->hh.tbl);                                             \
-    uthash_free((head)->hh.tbl->buckets,                                         \
-                (head)->hh.tbl->num_buckets * sizeof(struct UT_hash_bucket));    \
-    uthash_free((head)->hh.tbl, sizeof(UT_hash_table));                          \
-    (head) = NULL;                                                               \
-  } else {                                                                       \
-    unsigned _hd_bkt;                                                            \
-    if (_hd_hh_del == (head)->hh.tbl->tail) {                                    \
-      (head)->hh.tbl->tail = HH_FROM_ELMT((head)->hh.tbl, _hd_hh_del->prev);     \
-    }                                                                            \
-    if (_hd_hh_del->prev != NULL) {                                              \
-      HH_FROM_ELMT((head)->hh.tbl, _hd_hh_del->prev)->next = _hd_hh_del->next;   \
-    } else {                                                                     \
-      DECLTYPE_ASSIGN(head, _hd_hh_del->next);                                   \
-    }                                                                            \
-    if (_hd_hh_del->next != NULL) {                                              \
-      HH_FROM_ELMT((head)->hh.tbl, _hd_hh_del->next)->prev = _hd_hh_del->prev;   \
-    }                                                                            \
-    HASH_TO_BKT(_hd_hh_del->hashv, (head)->hh.tbl->num_buckets, _hd_bkt);        \
-    HASH_DEL_IN_BKT((head)->hh.tbl->buckets[_hd_bkt], _hd_hh_del);               \
-    (head)->hh.tbl->num_items--;                                                 \
-  }                                                                              \
-  HASH_FSCK(hh, head, "HASH_DELETE_HH");                                         \
-} while (0)
+#define HASH_DELETE_HH(hh, head, delptrhh)                                               \
+    do {                                                                                 \
+        struct UT_hash_handle *_hd_hh_del = (delptrhh);                                  \
+        if ((_hd_hh_del->prev == NULL) && (_hd_hh_del->next == NULL)) {                  \
+            HASH_BLOOM_FREE((head)->hh.tbl);                                             \
+            uthash_free((head)->hh.tbl->buckets,                                         \
+                (head)->hh.tbl->num_buckets * sizeof(struct UT_hash_bucket));            \
+            uthash_free((head)->hh.tbl, sizeof(UT_hash_table));                          \
+            (head) = NULL;                                                               \
+        } else {                                                                         \
+            unsigned _hd_bkt;                                                            \
+            if (_hd_hh_del == (head)->hh.tbl->tail) {                                    \
+                (head)->hh.tbl->tail = HH_FROM_ELMT((head)->hh.tbl, _hd_hh_del->prev);   \
+            }                                                                            \
+            if (_hd_hh_del->prev != NULL) {                                              \
+                HH_FROM_ELMT((head)->hh.tbl, _hd_hh_del->prev)->next = _hd_hh_del->next; \
+            } else {                                                                     \
+                DECLTYPE_ASSIGN(head, _hd_hh_del->next);                                 \
+            }                                                                            \
+            if (_hd_hh_del->next != NULL) {                                              \
+                HH_FROM_ELMT((head)->hh.tbl, _hd_hh_del->next)->prev = _hd_hh_del->prev; \
+            }                                                                            \
+            HASH_TO_BKT(_hd_hh_del->hashv, (head)->hh.tbl->num_buckets, _hd_bkt);        \
+            HASH_DEL_IN_BKT((head)->hh.tbl->buckets[_hd_bkt], _hd_hh_del);               \
+            (head)->hh.tbl->num_items--;                                                 \
+        }                                                                                \
+        HASH_FSCK(hh, head, "HASH_DELETE_HH");                                           \
+    } while (0)
 
 /* convenience forms of HASH_FIND/HASH_ADD/HASH_DEL */
-#define HASH_FIND_STR(head,findstr,out)                                          \
-do {                                                                             \
-    unsigned _uthash_hfstr_keylen = (unsigned)uthash_strlen(findstr);            \
-    HASH_FIND(hh, head, findstr, _uthash_hfstr_keylen, out);                     \
-} while (0)
-#define HASH_ADD_STR(head,strfield,add)                                          \
-do {                                                                             \
-    unsigned _uthash_hastr_keylen = (unsigned)uthash_strlen((add)->strfield);    \
-    HASH_ADD(hh, head, strfield[0], _uthash_hastr_keylen, add);                  \
-} while (0)
-#define HASH_REPLACE_STR(head,strfield,add,replaced)                             \
-do {                                                                             \
-    unsigned _uthash_hrstr_keylen = (unsigned)uthash_strlen((add)->strfield);    \
-    HASH_REPLACE(hh, head, strfield[0], _uthash_hrstr_keylen, add, replaced);    \
-} while (0)
-#define HASH_FIND_INT(head,findint,out)                                          \
-    HASH_FIND(hh,head,findint,sizeof(int),out)
-#define HASH_ADD_INT(head,intfield,add)                                          \
-    HASH_ADD(hh,head,intfield,sizeof(int),add)
-#define HASH_REPLACE_INT(head,intfield,add,replaced)                             \
-    HASH_REPLACE(hh,head,intfield,sizeof(int),add,replaced)
-#define HASH_FIND_PTR(head,findptr,out)                                          \
-    HASH_FIND(hh,head,findptr,sizeof(void *),out)
-#define HASH_ADD_PTR(head,ptrfield,add)                                          \
-    HASH_ADD(hh,head,ptrfield,sizeof(void *),add)
-#define HASH_REPLACE_PTR(head,ptrfield,add,replaced)                             \
-    HASH_REPLACE(hh,head,ptrfield,sizeof(void *),add,replaced)
-#define HASH_DEL(head,delptr)                                                    \
-    HASH_DELETE(hh,head,delptr)
+#define HASH_FIND_STR(head, findstr, out)                                 \
+    do {                                                                  \
+        unsigned _uthash_hfstr_keylen = (unsigned)uthash_strlen(findstr); \
+        HASH_FIND(hh, head, findstr, _uthash_hfstr_keylen, out);          \
+    } while (0)
+#define HASH_ADD_STR(head, strfield, add)                                         \
+    do {                                                                          \
+        unsigned _uthash_hastr_keylen = (unsigned)uthash_strlen((add)->strfield); \
+        HASH_ADD(hh, head, strfield[0], _uthash_hastr_keylen, add);               \
+    } while (0)
+#define HASH_REPLACE_STR(head, strfield, add, replaced)                           \
+    do {                                                                          \
+        unsigned _uthash_hrstr_keylen = (unsigned)uthash_strlen((add)->strfield); \
+        HASH_REPLACE(hh, head, strfield[0], _uthash_hrstr_keylen, add, replaced); \
+    } while (0)
+#define HASH_FIND_INT(head, findint, out) HASH_FIND(hh, head, findint, sizeof(int), out)
+#define HASH_ADD_INT(head, intfield, add) HASH_ADD(hh, head, intfield, sizeof(int), add)
+#define HASH_REPLACE_INT(head, intfield, add, replaced) \
+    HASH_REPLACE(hh, head, intfield, sizeof(int), add, replaced)
+#define HASH_FIND_PTR(head, findptr, out) HASH_FIND(hh, head, findptr, sizeof(void *), out)
+#define HASH_ADD_PTR(head, ptrfield, add) HASH_ADD(hh, head, ptrfield, sizeof(void *), add)
+#define HASH_REPLACE_PTR(head, ptrfield, add, replaced) \
+    HASH_REPLACE(hh, head, ptrfield, sizeof(void *), add, replaced)
+#define HASH_DEL(head, delptr) HASH_DELETE(hh, head, delptr)
 
 /* HASH_FSCK checks hash integrity on every add/delete when HASH_DEBUG is defined.
  * This is for uthash developer only; it compiles away if HASH_DEBUG isn't defined.
  */
 #ifdef HASH_DEBUG
-#define HASH_OOPS(...) do { fprintf(stderr,__VA_ARGS__); exit(-1); } while (0)
-#define HASH_FSCK(hh,head,where)                                                 \
-do {                                                                             \
-  struct UT_hash_handle *_thh;                                                   \
-  if (head) {                                                                    \
-    unsigned _bkt_i;                                                             \
-    unsigned _count = 0;                                                         \
-    char *_prev;                                                                 \
-    for (_bkt_i = 0; _bkt_i < (head)->hh.tbl->num_buckets; ++_bkt_i) {           \
-      unsigned _bkt_count = 0;                                                   \
-      _thh = (head)->hh.tbl->buckets[_bkt_i].hh_head;                            \
-      _prev = NULL;                                                              \
-      while (_thh) {                                                             \
-        if (_prev != (char*)(_thh->hh_prev)) {                                   \
-          HASH_OOPS("%s: invalid hh_prev %p, actual %p\n",                       \
-              (where), (void*)_thh->hh_prev, (void*)_prev);                      \
-        }                                                                        \
-        _bkt_count++;                                                            \
-        _prev = (char*)(_thh);                                                   \
-        _thh = _thh->hh_next;                                                    \
-      }                                                                          \
-      _count += _bkt_count;                                                      \
-      if ((head)->hh.tbl->buckets[_bkt_i].count !=  _bkt_count) {                \
-        HASH_OOPS("%s: invalid bucket count %u, actual %u\n",                    \
-            (where), (head)->hh.tbl->buckets[_bkt_i].count, _bkt_count);         \
-      }                                                                          \
-    }                                                                            \
-    if (_count != (head)->hh.tbl->num_items) {                                   \
-      HASH_OOPS("%s: invalid hh item count %u, actual %u\n",                     \
-          (where), (head)->hh.tbl->num_items, _count);                           \
-    }                                                                            \
-    _count = 0;                                                                  \
-    _prev = NULL;                                                                \
-    _thh =  &(head)->hh;                                                         \
-    while (_thh) {                                                               \
-      _count++;                                                                  \
-      if (_prev != (char*)_thh->prev) {                                          \
-        HASH_OOPS("%s: invalid prev %p, actual %p\n",                            \
-            (where), (void*)_thh->prev, (void*)_prev);                           \
-      }                                                                          \
-      _prev = (char*)ELMT_FROM_HH((head)->hh.tbl, _thh);                         \
-      _thh = (_thh->next ? HH_FROM_ELMT((head)->hh.tbl, _thh->next) : NULL);     \
-    }                                                                            \
-    if (_count != (head)->hh.tbl->num_items) {                                   \
-      HASH_OOPS("%s: invalid app item count %u, actual %u\n",                    \
-          (where), (head)->hh.tbl->num_items, _count);                           \
-    }                                                                            \
-  }                                                                              \
-} while (0)
+#define HASH_OOPS(...)                \
+    do {                              \
+        fprintf(stderr, __VA_ARGS__); \
+        exit(-1);                     \
+    } while (0)
+#define HASH_FSCK(hh, head, where)                                                             \
+    do {                                                                                       \
+        struct UT_hash_handle *_thh;                                                           \
+        if (head) {                                                                            \
+            unsigned _bkt_i;                                                                   \
+            unsigned _count = 0;                                                               \
+            char *_prev;                                                                       \
+            for (_bkt_i = 0; _bkt_i < (head)->hh.tbl->num_buckets; ++_bkt_i) {                 \
+                unsigned _bkt_count = 0;                                                       \
+                _thh = (head)->hh.tbl->buckets[_bkt_i].hh_head;                                \
+                _prev = NULL;                                                                  \
+                while (_thh) {                                                                 \
+                    if (_prev != (char *)(_thh->hh_prev)) {                                    \
+                        HASH_OOPS("%s: invalid hh_prev %p, actual %p\n", (where),              \
+                            (void *)_thh->hh_prev, (void *)_prev);                             \
+                    }                                                                          \
+                    _bkt_count++;                                                              \
+                    _prev = (char *)(_thh);                                                    \
+                    _thh = _thh->hh_next;                                                      \
+                }                                                                              \
+                _count += _bkt_count;                                                          \
+                if ((head)->hh.tbl->buckets[_bkt_i].count != _bkt_count) {                     \
+                    HASH_OOPS("%s: invalid bucket count %u, actual %u\n", (where),             \
+                        (head)->hh.tbl->buckets[_bkt_i].count, _bkt_count);                    \
+                }                                                                              \
+            }                                                                                  \
+            if (_count != (head)->hh.tbl->num_items) {                                         \
+                HASH_OOPS("%s: invalid hh item count %u, actual %u\n", (where),                \
+                    (head)->hh.tbl->num_items, _count);                                        \
+            }                                                                                  \
+            _count = 0;                                                                        \
+            _prev = NULL;                                                                      \
+            _thh = &(head)->hh;                                                                \
+            while (_thh) {                                                                     \
+                _count++;                                                                      \
+                if (_prev != (char *)_thh->prev) {                                             \
+                    HASH_OOPS("%s: invalid prev %p, actual %p\n", (where), (void *)_thh->prev, \
+                        (void *)_prev);                                                        \
+                }                                                                              \
+                _prev = (char *)ELMT_FROM_HH((head)->hh.tbl, _thh);                            \
+                _thh = (_thh->next ? HH_FROM_ELMT((head)->hh.tbl, _thh->next) : NULL);         \
+            }                                                                                  \
+            if (_count != (head)->hh.tbl->num_items) {                                         \
+                HASH_OOPS("%s: invalid app item count %u, actual %u\n", (where),               \
+                    (head)->hh.tbl->num_items, _count);                                        \
+            }                                                                                  \
+        }                                                                                      \
+    } while (0)
 #else
-#define HASH_FSCK(hh,head,where)
+#define HASH_FSCK(hh, head, where)
 #endif
 
 /* When compiled with -DHASH_EMIT_KEYS, length-prefixed keys are emitted to
  * the descriptor to which this macro is defined for tuning the hash function.
  * The app can #include <unistd.h> to get the prototype for write(2). */
 #ifdef HASH_EMIT_KEYS
-#define HASH_EMIT_KEY(hh,head,keyptr,fieldlen)                                   \
-do {                                                                             \
-  unsigned _klen = fieldlen;                                                     \
-  write(HASH_EMIT_KEYS, &_klen, sizeof(_klen));                                  \
-  write(HASH_EMIT_KEYS, keyptr, (unsigned long)fieldlen);                        \
-} while (0)
+#define HASH_EMIT_KEY(hh, head, keyptr, fieldlen)               \
+    do {                                                        \
+        unsigned _klen = fieldlen;                              \
+        write(HASH_EMIT_KEYS, &_klen, sizeof(_klen));           \
+        write(HASH_EMIT_KEYS, keyptr, (unsigned long)fieldlen); \
+    } while (0)
 #else
-#define HASH_EMIT_KEY(hh,head,keyptr,fieldlen)
+#define HASH_EMIT_KEY(hh, head, keyptr, fieldlen)
 #endif
 
 /* default to Jenkin's hash unless overridden e.g. DHASH_FUNCTION=HASH_SAX */
@@ -586,161 +594,189 @@ do {                                                                            
 #endif
 
 /* The Bernstein hash function, used in Perl prior to v5.6. Note (x<<5+x)=x*33. */
-#define HASH_BER(key,keylen,hashv)                                               \
-do {                                                                             \
-  unsigned _hb_keylen = (unsigned)keylen;                                        \
-  const unsigned char *_hb_key = (const unsigned char*)(key);                    \
-  (hashv) = 0;                                                                   \
-  while (_hb_keylen-- != 0U) {                                                   \
-    (hashv) = (((hashv) << 5) + (hashv)) + *_hb_key++;                           \
-  }                                                                              \
-} while (0)
-
+#define HASH_BER(key, keylen, hashv)                                 \
+    do {                                                             \
+        unsigned _hb_keylen = (unsigned)keylen;                      \
+        const unsigned char *_hb_key = (const unsigned char *)(key); \
+        (hashv) = 0;                                                 \
+        while (_hb_keylen-- != 0U) {                                 \
+            (hashv) = (((hashv) << 5) + (hashv)) + *_hb_key++;       \
+        }                                                            \
+    } while (0)
 
 /* SAX/FNV/OAT/JEN hash functions are macro variants of those listed at
  * http://eternallyconfuzzled.com/tuts/algorithms/jsw_tut_hashing.aspx */
-#define HASH_SAX(key,keylen,hashv)                                               \
-do {                                                                             \
-  unsigned _sx_i;                                                                \
-  const unsigned char *_hs_key = (const unsigned char*)(key);                    \
-  hashv = 0;                                                                     \
-  for (_sx_i=0; _sx_i < keylen; _sx_i++) {                                       \
-    hashv ^= (hashv << 5) + (hashv >> 2) + _hs_key[_sx_i];                       \
-  }                                                                              \
-} while (0)
+#define HASH_SAX(key, keylen, hashv)                                 \
+    do {                                                             \
+        unsigned _sx_i;                                              \
+        const unsigned char *_hs_key = (const unsigned char *)(key); \
+        hashv = 0;                                                   \
+        for (_sx_i = 0; _sx_i < keylen; _sx_i++) {                   \
+            hashv ^= (hashv << 5) + (hashv >> 2) + _hs_key[_sx_i];   \
+        }                                                            \
+    } while (0)
 /* FNV-1a variation */
-#define HASH_FNV(key,keylen,hashv)                                               \
-do {                                                                             \
-  unsigned _fn_i;                                                                \
-  const unsigned char *_hf_key = (const unsigned char*)(key);                    \
-  (hashv) = 2166136261U;                                                         \
-  for (_fn_i=0; _fn_i < keylen; _fn_i++) {                                       \
-    hashv = hashv ^ _hf_key[_fn_i];                                              \
-    hashv = hashv * 16777619U;                                                   \
-  }                                                                              \
-} while (0)
+#define HASH_FNV(key, keylen, hashv)                                 \
+    do {                                                             \
+        unsigned _fn_i;                                              \
+        const unsigned char *_hf_key = (const unsigned char *)(key); \
+        (hashv) = 2166136261U;                                       \
+        for (_fn_i = 0; _fn_i < keylen; _fn_i++) {                   \
+            hashv = hashv ^ _hf_key[_fn_i];                          \
+            hashv = hashv * 16777619U;                               \
+        }                                                            \
+    } while (0)
 
-#define HASH_OAT(key,keylen,hashv)                                               \
-do {                                                                             \
-  unsigned _ho_i;                                                                \
-  const unsigned char *_ho_key=(const unsigned char*)(key);                      \
-  hashv = 0;                                                                     \
-  for(_ho_i=0; _ho_i < keylen; _ho_i++) {                                        \
-      hashv += _ho_key[_ho_i];                                                   \
-      hashv += (hashv << 10);                                                    \
-      hashv ^= (hashv >> 6);                                                     \
-  }                                                                              \
-  hashv += (hashv << 3);                                                         \
-  hashv ^= (hashv >> 11);                                                        \
-  hashv += (hashv << 15);                                                        \
-} while (0)
+#define HASH_OAT(key, keylen, hashv)                                 \
+    do {                                                             \
+        unsigned _ho_i;                                              \
+        const unsigned char *_ho_key = (const unsigned char *)(key); \
+        hashv = 0;                                                   \
+        for (_ho_i = 0; _ho_i < keylen; _ho_i++) {                   \
+            hashv += _ho_key[_ho_i];                                 \
+            hashv += (hashv << 10);                                  \
+            hashv ^= (hashv >> 6);                                   \
+        }                                                            \
+        hashv += (hashv << 3);                                       \
+        hashv ^= (hashv >> 11);                                      \
+        hashv += (hashv << 15);                                      \
+    } while (0)
 
-#define HASH_JEN_MIX(a,b,c)                                                      \
-do {                                                                             \
-  a -= b; a -= c; a ^= ( c >> 13 );                                              \
-  b -= c; b -= a; b ^= ( a << 8 );                                               \
-  c -= a; c -= b; c ^= ( b >> 13 );                                              \
-  a -= b; a -= c; a ^= ( c >> 12 );                                              \
-  b -= c; b -= a; b ^= ( a << 16 );                                              \
-  c -= a; c -= b; c ^= ( b >> 5 );                                               \
-  a -= b; a -= c; a ^= ( c >> 3 );                                               \
-  b -= c; b -= a; b ^= ( a << 10 );                                              \
-  c -= a; c -= b; c ^= ( b >> 15 );                                              \
-} while (0)
+#define HASH_JEN_MIX(a, b, c) \
+    do {                      \
+        a -= b;               \
+        a -= c;               \
+        a ^= (c >> 13);       \
+        b -= c;               \
+        b -= a;               \
+        b ^= (a << 8);        \
+        c -= a;               \
+        c -= b;               \
+        c ^= (b >> 13);       \
+        a -= b;               \
+        a -= c;               \
+        a ^= (c >> 12);       \
+        b -= c;               \
+        b -= a;               \
+        b ^= (a << 16);       \
+        c -= a;               \
+        c -= b;               \
+        c ^= (b >> 5);        \
+        a -= b;               \
+        a -= c;               \
+        a ^= (c >> 3);        \
+        b -= c;               \
+        b -= a;               \
+        b ^= (a << 10);       \
+        c -= a;               \
+        c -= b;               \
+        c ^= (b >> 15);       \
+    } while (0)
 
-#define HASH_JEN(key,keylen,hashv)                                               \
-do {                                                                             \
-  unsigned _hj_i,_hj_j,_hj_k;                                                    \
-  unsigned const char *_hj_key=(unsigned const char*)(key);                      \
-  hashv = 0xfeedbeefu;                                                           \
-  _hj_i = _hj_j = 0x9e3779b9u;                                                   \
-  _hj_k = (unsigned)(keylen);                                                    \
-  while (_hj_k >= 12U) {                                                         \
-    _hj_i +=    (_hj_key[0] + ( (unsigned)_hj_key[1] << 8 )                      \
-        + ( (unsigned)_hj_key[2] << 16 )                                         \
-        + ( (unsigned)_hj_key[3] << 24 ) );                                      \
-    _hj_j +=    (_hj_key[4] + ( (unsigned)_hj_key[5] << 8 )                      \
-        + ( (unsigned)_hj_key[6] << 16 )                                         \
-        + ( (unsigned)_hj_key[7] << 24 ) );                                      \
-    hashv += (_hj_key[8] + ( (unsigned)_hj_key[9] << 8 )                         \
-        + ( (unsigned)_hj_key[10] << 16 )                                        \
-        + ( (unsigned)_hj_key[11] << 24 ) );                                     \
-                                                                                 \
-     HASH_JEN_MIX(_hj_i, _hj_j, hashv);                                          \
-                                                                                 \
-     _hj_key += 12;                                                              \
-     _hj_k -= 12U;                                                               \
-  }                                                                              \
-  hashv += (unsigned)(keylen);                                                   \
-  switch ( _hj_k ) {                                                             \
-    case 11: hashv += ( (unsigned)_hj_key[10] << 24 ); /* FALLTHROUGH */         \
-    case 10: hashv += ( (unsigned)_hj_key[9] << 16 );  /* FALLTHROUGH */         \
-    case 9:  hashv += ( (unsigned)_hj_key[8] << 8 );   /* FALLTHROUGH */         \
-    case 8:  _hj_j += ( (unsigned)_hj_key[7] << 24 );  /* FALLTHROUGH */         \
-    case 7:  _hj_j += ( (unsigned)_hj_key[6] << 16 );  /* FALLTHROUGH */         \
-    case 6:  _hj_j += ( (unsigned)_hj_key[5] << 8 );   /* FALLTHROUGH */         \
-    case 5:  _hj_j += _hj_key[4];                      /* FALLTHROUGH */         \
-    case 4:  _hj_i += ( (unsigned)_hj_key[3] << 24 );  /* FALLTHROUGH */         \
-    case 3:  _hj_i += ( (unsigned)_hj_key[2] << 16 );  /* FALLTHROUGH */         \
-    case 2:  _hj_i += ( (unsigned)_hj_key[1] << 8 );   /* FALLTHROUGH */         \
-    case 1:  _hj_i += _hj_key[0];                                                \
-  }                                                                              \
-  HASH_JEN_MIX(_hj_i, _hj_j, hashv);                                             \
-} while (0)
+#define HASH_JEN(key, keylen, hashv)                                                           \
+    do {                                                                                       \
+        unsigned _hj_i, _hj_j, _hj_k;                                                          \
+        unsigned const char *_hj_key = (unsigned const char *)(key);                           \
+        hashv = 0xfeedbeefu;                                                                   \
+        _hj_i = _hj_j = 0x9e3779b9u;                                                           \
+        _hj_k = (unsigned)(keylen);                                                            \
+        while (_hj_k >= 12U) {                                                                 \
+            _hj_i += (_hj_key[0] + ((unsigned)_hj_key[1] << 8) + ((unsigned)_hj_key[2] << 16)  \
+                + ((unsigned)_hj_key[3] << 24));                                               \
+            _hj_j += (_hj_key[4] + ((unsigned)_hj_key[5] << 8) + ((unsigned)_hj_key[6] << 16)  \
+                + ((unsigned)_hj_key[7] << 24));                                               \
+            hashv += (_hj_key[8] + ((unsigned)_hj_key[9] << 8) + ((unsigned)_hj_key[10] << 16) \
+                + ((unsigned)_hj_key[11] << 24));                                              \
+                                                                                               \
+            HASH_JEN_MIX(_hj_i, _hj_j, hashv);                                                 \
+                                                                                               \
+            _hj_key += 12;                                                                     \
+            _hj_k -= 12U;                                                                      \
+        }                                                                                      \
+        hashv += (unsigned)(keylen);                                                           \
+        switch (_hj_k) {                                                                       \
+        case 11:                                                                               \
+            hashv += ((unsigned)_hj_key[10] << 24); /* FALLTHROUGH */                          \
+        case 10:                                                                               \
+            hashv += ((unsigned)_hj_key[9] << 16); /* FALLTHROUGH */                           \
+        case 9:                                                                                \
+            hashv += ((unsigned)_hj_key[8] << 8); /* FALLTHROUGH */                            \
+        case 8:                                                                                \
+            _hj_j += ((unsigned)_hj_key[7] << 24); /* FALLTHROUGH */                           \
+        case 7:                                                                                \
+            _hj_j += ((unsigned)_hj_key[6] << 16); /* FALLTHROUGH */                           \
+        case 6:                                                                                \
+            _hj_j += ((unsigned)_hj_key[5] << 8); /* FALLTHROUGH */                            \
+        case 5:                                                                                \
+            _hj_j += _hj_key[4]; /* FALLTHROUGH */                                             \
+        case 4:                                                                                \
+            _hj_i += ((unsigned)_hj_key[3] << 24); /* FALLTHROUGH */                           \
+        case 3:                                                                                \
+            _hj_i += ((unsigned)_hj_key[2] << 16); /* FALLTHROUGH */                           \
+        case 2:                                                                                \
+            _hj_i += ((unsigned)_hj_key[1] << 8); /* FALLTHROUGH */                            \
+        case 1:                                                                                \
+            _hj_i += _hj_key[0];                                                               \
+        }                                                                                      \
+        HASH_JEN_MIX(_hj_i, _hj_j, hashv);                                                     \
+    } while (0)
 
 /* The Paul Hsieh hash function */
 #undef get16bits
-#if (defined(__GNUC__) && defined(__i386__)) || defined(__WATCOMC__)             \
-  || defined(_MSC_VER) || defined (__BORLANDC__) || defined (__TURBOC__)
-#define get16bits(d) (*((const uint16_t *) (d)))
+#if (defined(__GNUC__) && defined(__i386__)) || defined(__WATCOMC__) || defined(_MSC_VER) \
+    || defined(__BORLANDC__) || defined(__TURBOC__)
+#define get16bits(d) (*((const uint16_t *)(d)))
 #endif
 
-#if !defined (get16bits)
-#define get16bits(d) ((((uint32_t)(((const uint8_t *)(d))[1])) << 8)             \
-                       +(uint32_t)(((const uint8_t *)(d))[0]) )
+#if !defined(get16bits)
+#define get16bits(d) \
+    ((((uint32_t)(((const uint8_t *)(d))[1])) << 8) + (uint32_t)(((const uint8_t *)(d))[0]))
 #endif
-#define HASH_SFH(key,keylen,hashv)                                               \
-do {                                                                             \
-  unsigned const char *_sfh_key=(unsigned const char*)(key);                     \
-  uint32_t _sfh_tmp, _sfh_len = (uint32_t)keylen;                                \
-                                                                                 \
-  unsigned _sfh_rem = _sfh_len & 3U;                                             \
-  _sfh_len >>= 2;                                                                \
-  hashv = 0xcafebabeu;                                                           \
-                                                                                 \
-  /* Main loop */                                                                \
-  for (;_sfh_len > 0U; _sfh_len--) {                                             \
-    hashv    += get16bits (_sfh_key);                                            \
-    _sfh_tmp  = ((uint32_t)(get16bits (_sfh_key+2)) << 11) ^ hashv;              \
-    hashv     = (hashv << 16) ^ _sfh_tmp;                                        \
-    _sfh_key += 2U*sizeof (uint16_t);                                            \
-    hashv    += hashv >> 11;                                                     \
-  }                                                                              \
-                                                                                 \
-  /* Handle end cases */                                                         \
-  switch (_sfh_rem) {                                                            \
-    case 3: hashv += get16bits (_sfh_key);                                       \
-            hashv ^= hashv << 16;                                                \
-            hashv ^= (uint32_t)(_sfh_key[sizeof (uint16_t)]) << 18;              \
-            hashv += hashv >> 11;                                                \
-            break;                                                               \
-    case 2: hashv += get16bits (_sfh_key);                                       \
-            hashv ^= hashv << 11;                                                \
-            hashv += hashv >> 17;                                                \
-            break;                                                               \
-    case 1: hashv += *_sfh_key;                                                  \
-            hashv ^= hashv << 10;                                                \
-            hashv += hashv >> 1;                                                 \
-  }                                                                              \
-                                                                                 \
-  /* Force "avalanching" of final 127 bits */                                    \
-  hashv ^= hashv << 3;                                                           \
-  hashv += hashv >> 5;                                                           \
-  hashv ^= hashv << 4;                                                           \
-  hashv += hashv >> 17;                                                          \
-  hashv ^= hashv << 25;                                                          \
-  hashv += hashv >> 6;                                                           \
-} while (0)
+#define HASH_SFH(key, keylen, hashv)                                        \
+    do {                                                                    \
+        unsigned const char *_sfh_key = (unsigned const char *)(key);       \
+        uint32_t _sfh_tmp, _sfh_len = (uint32_t)keylen;                     \
+                                                                            \
+        unsigned _sfh_rem = _sfh_len & 3U;                                  \
+        _sfh_len >>= 2;                                                     \
+        hashv = 0xcafebabeu;                                                \
+                                                                            \
+        /* Main loop */                                                     \
+        for (; _sfh_len > 0U; _sfh_len--) {                                 \
+            hashv += get16bits(_sfh_key);                                   \
+            _sfh_tmp = ((uint32_t)(get16bits(_sfh_key + 2)) << 11) ^ hashv; \
+            hashv = (hashv << 16) ^ _sfh_tmp;                               \
+            _sfh_key += 2U * sizeof(uint16_t);                              \
+            hashv += hashv >> 11;                                           \
+        }                                                                   \
+                                                                            \
+        /* Handle end cases */                                              \
+        switch (_sfh_rem) {                                                 \
+        case 3:                                                             \
+            hashv += get16bits(_sfh_key);                                   \
+            hashv ^= hashv << 16;                                           \
+            hashv ^= (uint32_t)(_sfh_key[sizeof(uint16_t)]) << 18;          \
+            hashv += hashv >> 11;                                           \
+            break;                                                          \
+        case 2:                                                             \
+            hashv += get16bits(_sfh_key);                                   \
+            hashv ^= hashv << 11;                                           \
+            hashv += hashv >> 17;                                           \
+            break;                                                          \
+        case 1:                                                             \
+            hashv += *_sfh_key;                                             \
+            hashv ^= hashv << 10;                                           \
+            hashv += hashv >> 1;                                            \
+        }                                                                   \
+                                                                            \
+        /* Force "avalanching" of final 127 bits */                         \
+        hashv ^= hashv << 3;                                                \
+        hashv += hashv >> 5;                                                \
+        hashv ^= hashv << 4;                                                \
+        hashv += hashv >> 17;                                               \
+        hashv ^= hashv << 25;                                               \
+        hashv += hashv >> 6;                                                \
+    } while (0)
 
 #ifdef HASH_USING_NO_STRICT_ALIASING
 /* The MurmurHash exploits some CPU's (x86,x86_64) tolerance for unaligned reads.
@@ -752,136 +788,137 @@ do {                                                                            
  *   gcc -m64 -dM -E - < /dev/null                  (on gcc)
  *   cc -## a.c (where a.c is a simple test file)   (Sun Studio)
  */
-#if (defined(__i386__) || defined(__x86_64__)  || defined(_M_IX86))
-#define MUR_GETBLOCK(p,i) p[i]
+#if (defined(__i386__) || defined(__x86_64__) || defined(_M_IX86))
+#define MUR_GETBLOCK(p, i) p[i]
 #else /* non intel */
 #define MUR_PLUS0_ALIGNED(p) (((unsigned long)p & 3UL) == 0UL)
 #define MUR_PLUS1_ALIGNED(p) (((unsigned long)p & 3UL) == 1UL)
 #define MUR_PLUS2_ALIGNED(p) (((unsigned long)p & 3UL) == 2UL)
 #define MUR_PLUS3_ALIGNED(p) (((unsigned long)p & 3UL) == 3UL)
-#define WP(p) ((uint32_t*)((unsigned long)(p) & ~3UL))
+#define WP(p)                ((uint32_t *)((unsigned long)(p) & ~3UL))
 #if (defined(__BIG_ENDIAN__) || defined(SPARC) || defined(__ppc__) || defined(__ppc64__))
-#define MUR_THREE_ONE(p) ((((*WP(p))&0x00ffffff) << 8) | (((*(WP(p)+1))&0xff000000) >> 24))
-#define MUR_TWO_TWO(p)   ((((*WP(p))&0x0000ffff) <<16) | (((*(WP(p)+1))&0xffff0000) >> 16))
-#define MUR_ONE_THREE(p) ((((*WP(p))&0x000000ff) <<24) | (((*(WP(p)+1))&0xffffff00) >>  8))
+#define MUR_THREE_ONE(p) ((((*WP(p)) & 0x00ffffff) << 8) | (((*(WP(p) + 1)) & 0xff000000) >> 24))
+#define MUR_TWO_TWO(p)   ((((*WP(p)) & 0x0000ffff) << 16) | (((*(WP(p) + 1)) & 0xffff0000) >> 16))
+#define MUR_ONE_THREE(p) ((((*WP(p)) & 0x000000ff) << 24) | (((*(WP(p) + 1)) & 0xffffff00) >> 8))
 #else /* assume little endian non-intel */
-#define MUR_THREE_ONE(p) ((((*WP(p))&0xffffff00) >> 8) | (((*(WP(p)+1))&0x000000ff) << 24))
-#define MUR_TWO_TWO(p)   ((((*WP(p))&0xffff0000) >>16) | (((*(WP(p)+1))&0x0000ffff) << 16))
-#define MUR_ONE_THREE(p) ((((*WP(p))&0xff000000) >>24) | (((*(WP(p)+1))&0x00ffffff) <<  8))
+#define MUR_THREE_ONE(p) ((((*WP(p)) & 0xffffff00) >> 8) | (((*(WP(p) + 1)) & 0x000000ff) << 24))
+#define MUR_TWO_TWO(p)   ((((*WP(p)) & 0xffff0000) >> 16) | (((*(WP(p) + 1)) & 0x0000ffff) << 16))
+#define MUR_ONE_THREE(p) ((((*WP(p)) & 0xff000000) >> 24) | (((*(WP(p) + 1)) & 0x00ffffff) << 8))
 #endif
-#define MUR_GETBLOCK(p,i) (MUR_PLUS0_ALIGNED(p) ? ((p)[i]) :           \
-                            (MUR_PLUS1_ALIGNED(p) ? MUR_THREE_ONE(p) : \
-                             (MUR_PLUS2_ALIGNED(p) ? MUR_TWO_TWO(p) :  \
-                                                      MUR_ONE_THREE(p))))
+#define MUR_GETBLOCK(p, i)                             \
+    (MUR_PLUS0_ALIGNED(p)                              \
+            ? ((p)[i])                                 \
+            : (MUR_PLUS1_ALIGNED(p) ? MUR_THREE_ONE(p) \
+                                    : (MUR_PLUS2_ALIGNED(p) ? MUR_TWO_TWO(p) : MUR_ONE_THREE(p))))
 #endif
-#define MUR_ROTL32(x,r) (((x) << (r)) | ((x) >> (32 - (r))))
-#define MUR_FMIX(_h) \
-do {                 \
-  _h ^= _h >> 16;    \
-  _h *= 0x85ebca6bu; \
-  _h ^= _h >> 13;    \
-  _h *= 0xc2b2ae35u; \
-  _h ^= _h >> 16;    \
-} while (0)
+#define MUR_ROTL32(x, r) (((x) << (r)) | ((x) >> (32 - (r))))
+#define MUR_FMIX(_h)       \
+    do {                   \
+        _h ^= _h >> 16;    \
+        _h *= 0x85ebca6bu; \
+        _h ^= _h >> 13;    \
+        _h *= 0xc2b2ae35u; \
+        _h ^= _h >> 16;    \
+    } while (0)
 
-#define HASH_MUR(key,keylen,hashv)                                     \
-do {                                                                   \
-  const uint8_t *_mur_data = (const uint8_t*)(key);                    \
-  const int _mur_nblocks = (int)(keylen) / 4;                          \
-  uint32_t _mur_h1 = 0xf88D5353u;                                      \
-  uint32_t _mur_c1 = 0xcc9e2d51u;                                      \
-  uint32_t _mur_c2 = 0x1b873593u;                                      \
-  uint32_t _mur_k1 = 0;                                                \
-  const uint8_t *_mur_tail;                                            \
-  const uint32_t *_mur_blocks = (const uint32_t*)(_mur_data+(_mur_nblocks*4)); \
-  int _mur_i;                                                          \
-  for (_mur_i = -_mur_nblocks; _mur_i != 0; _mur_i++) {                \
-    _mur_k1 = MUR_GETBLOCK(_mur_blocks,_mur_i);                        \
-    _mur_k1 *= _mur_c1;                                                \
-    _mur_k1 = MUR_ROTL32(_mur_k1,15);                                  \
-    _mur_k1 *= _mur_c2;                                                \
-                                                                       \
-    _mur_h1 ^= _mur_k1;                                                \
-    _mur_h1 = MUR_ROTL32(_mur_h1,13);                                  \
-    _mur_h1 = (_mur_h1*5U) + 0xe6546b64u;                              \
-  }                                                                    \
-  _mur_tail = (const uint8_t*)(_mur_data + (_mur_nblocks*4));          \
-  _mur_k1=0;                                                           \
-  switch ((keylen) & 3U) {                                             \
-    case 0: break;                                                     \
-    case 3: _mur_k1 ^= (uint32_t)_mur_tail[2] << 16; /* FALLTHROUGH */ \
-    case 2: _mur_k1 ^= (uint32_t)_mur_tail[1] << 8;  /* FALLTHROUGH */ \
-    case 1: _mur_k1 ^= (uint32_t)_mur_tail[0];                         \
-    _mur_k1 *= _mur_c1;                                                \
-    _mur_k1 = MUR_ROTL32(_mur_k1,15);                                  \
-    _mur_k1 *= _mur_c2;                                                \
-    _mur_h1 ^= _mur_k1;                                                \
-  }                                                                    \
-  _mur_h1 ^= (uint32_t)(keylen);                                       \
-  MUR_FMIX(_mur_h1);                                                   \
-  hashv = _mur_h1;                                                     \
-} while (0)
-#endif  /* HASH_USING_NO_STRICT_ALIASING */
+#define HASH_MUR(key, keylen, hashv)                                                      \
+    do {                                                                                  \
+        const uint8_t *_mur_data = (const uint8_t *)(key);                                \
+        const int _mur_nblocks = (int)(keylen) / 4;                                       \
+        uint32_t _mur_h1 = 0xf88D5353u;                                                   \
+        uint32_t _mur_c1 = 0xcc9e2d51u;                                                   \
+        uint32_t _mur_c2 = 0x1b873593u;                                                   \
+        uint32_t _mur_k1 = 0;                                                             \
+        const uint8_t *_mur_tail;                                                         \
+        const uint32_t *_mur_blocks = (const uint32_t *)(_mur_data + (_mur_nblocks * 4)); \
+        int _mur_i;                                                                       \
+        for (_mur_i = -_mur_nblocks; _mur_i != 0; _mur_i++) {                             \
+            _mur_k1 = MUR_GETBLOCK(_mur_blocks, _mur_i);                                  \
+            _mur_k1 *= _mur_c1;                                                           \
+            _mur_k1 = MUR_ROTL32(_mur_k1, 15);                                            \
+            _mur_k1 *= _mur_c2;                                                           \
+                                                                                          \
+            _mur_h1 ^= _mur_k1;                                                           \
+            _mur_h1 = MUR_ROTL32(_mur_h1, 13);                                            \
+            _mur_h1 = (_mur_h1 * 5U) + 0xe6546b64u;                                       \
+        }                                                                                 \
+        _mur_tail = (const uint8_t *)(_mur_data + (_mur_nblocks * 4));                    \
+        _mur_k1 = 0;                                                                      \
+        switch ((keylen)&3U) {                                                            \
+        case 0:                                                                           \
+            break;                                                                        \
+        case 3:                                                                           \
+            _mur_k1 ^= (uint32_t)_mur_tail[2] << 16; /* FALLTHROUGH */                    \
+        case 2:                                                                           \
+            _mur_k1 ^= (uint32_t)_mur_tail[1] << 8; /* FALLTHROUGH */                     \
+        case 1:                                                                           \
+            _mur_k1 ^= (uint32_t)_mur_tail[0];                                            \
+            _mur_k1 *= _mur_c1;                                                           \
+            _mur_k1 = MUR_ROTL32(_mur_k1, 15);                                            \
+            _mur_k1 *= _mur_c2;                                                           \
+            _mur_h1 ^= _mur_k1;                                                           \
+        }                                                                                 \
+        _mur_h1 ^= (uint32_t)(keylen);                                                    \
+        MUR_FMIX(_mur_h1);                                                                \
+        hashv = _mur_h1;                                                                  \
+    } while (0)
+#endif /* HASH_USING_NO_STRICT_ALIASING */
 
 /* iterate over items in a known bucket to find desired item */
-#define HASH_FIND_IN_BKT(tbl,hh,head,keyptr,keylen_in,hashval,out)               \
-do {                                                                             \
-  if ((head).hh_head != NULL) {                                                  \
-    DECLTYPE_ASSIGN(out, ELMT_FROM_HH(tbl, (head).hh_head));                     \
-  } else {                                                                       \
-    (out) = NULL;                                                                \
-  }                                                                              \
-  while ((out) != NULL) {                                                        \
-    if ((out)->hh.hashv == (hashval) && (out)->hh.keylen == (keylen_in)) {       \
-      if (uthash_memcmp((out)->hh.key, keyptr, keylen_in) == 0) {                \
-        break;                                                                   \
-      }                                                                          \
-    }                                                                            \
-    if ((out)->hh.hh_next != NULL) {                                             \
-      DECLTYPE_ASSIGN(out, ELMT_FROM_HH(tbl, (out)->hh.hh_next));                \
-    } else {                                                                     \
-      (out) = NULL;                                                              \
-    }                                                                            \
-  }                                                                              \
-} while (0)
+#define HASH_FIND_IN_BKT(tbl, hh, head, keyptr, keylen_in, hashval, out)           \
+    do {                                                                           \
+        if ((head).hh_head != NULL) {                                              \
+            DECLTYPE_ASSIGN(out, ELMT_FROM_HH(tbl, (head).hh_head));               \
+        } else {                                                                   \
+            (out) = NULL;                                                          \
+        }                                                                          \
+        while ((out) != NULL) {                                                    \
+            if ((out)->hh.hashv == (hashval) && (out)->hh.keylen == (keylen_in)) { \
+                if (uthash_memcmp((out)->hh.key, keyptr, keylen_in) == 0) {        \
+                    break;                                                         \
+                }                                                                  \
+            }                                                                      \
+            if ((out)->hh.hh_next != NULL) {                                       \
+                DECLTYPE_ASSIGN(out, ELMT_FROM_HH(tbl, (out)->hh.hh_next));        \
+            } else {                                                               \
+                (out) = NULL;                                                      \
+            }                                                                      \
+        }                                                                          \
+    } while (0)
 
 /* add an item to a bucket  */
-#define HASH_ADD_TO_BKT(head,hh,addhh,oomed)                                     \
-do {                                                                             \
-  UT_hash_bucket *_ha_head = &(head);                                            \
-  _ha_head->count++;                                                             \
-  (addhh)->hh_next = _ha_head->hh_head;                                          \
-  (addhh)->hh_prev = NULL;                                                       \
-  if (_ha_head->hh_head != NULL) {                                               \
-    _ha_head->hh_head->hh_prev = (addhh);                                        \
-  }                                                                              \
-  _ha_head->hh_head = (addhh);                                                   \
-  if ((_ha_head->count >= ((_ha_head->expand_mult + 1U) * HASH_BKT_CAPACITY_THRESH)) \
-      && !(addhh)->tbl->noexpand) {                                              \
-    HASH_EXPAND_BUCKETS(addhh,(addhh)->tbl, oomed);                              \
-    IF_HASH_NONFATAL_OOM(                                                        \
-      if (oomed) {                                                               \
-        HASH_DEL_IN_BKT(head,addhh);                                             \
-      }                                                                          \
-    )                                                                            \
-  }                                                                              \
-} while (0)
+#define HASH_ADD_TO_BKT(head, hh, addhh, oomed)                                            \
+    do {                                                                                   \
+        UT_hash_bucket *_ha_head = &(head);                                                \
+        _ha_head->count++;                                                                 \
+        (addhh)->hh_next = _ha_head->hh_head;                                              \
+        (addhh)->hh_prev = NULL;                                                           \
+        if (_ha_head->hh_head != NULL) {                                                   \
+            _ha_head->hh_head->hh_prev = (addhh);                                          \
+        }                                                                                  \
+        _ha_head->hh_head = (addhh);                                                       \
+        if ((_ha_head->count >= ((_ha_head->expand_mult + 1U) * HASH_BKT_CAPACITY_THRESH)) \
+            && !(addhh)->tbl->noexpand) {                                                  \
+            HASH_EXPAND_BUCKETS(addhh, (addhh)->tbl, oomed);                               \
+            IF_HASH_NONFATAL_OOM(if (oomed) { HASH_DEL_IN_BKT(head, addhh); })             \
+        }                                                                                  \
+    } while (0)
 
 /* remove an item from a given bucket */
-#define HASH_DEL_IN_BKT(head,delhh)                                              \
-do {                                                                             \
-  UT_hash_bucket *_hd_head = &(head);                                            \
-  _hd_head->count--;                                                             \
-  if (_hd_head->hh_head == (delhh)) {                                            \
-    _hd_head->hh_head = (delhh)->hh_next;                                        \
-  }                                                                              \
-  if ((delhh)->hh_prev) {                                                        \
-    (delhh)->hh_prev->hh_next = (delhh)->hh_next;                                \
-  }                                                                              \
-  if ((delhh)->hh_next) {                                                        \
-    (delhh)->hh_next->hh_prev = (delhh)->hh_prev;                                \
-  }                                                                              \
-} while (0)
+#define HASH_DEL_IN_BKT(head, delhh)                      \
+    do {                                                  \
+        UT_hash_bucket *_hd_head = &(head);               \
+        _hd_head->count--;                                \
+        if (_hd_head->hh_head == (delhh)) {               \
+            _hd_head->hh_head = (delhh)->hh_next;         \
+        }                                                 \
+        if ((delhh)->hh_prev) {                           \
+            (delhh)->hh_prev->hh_next = (delhh)->hh_next; \
+        }                                                 \
+        if ((delhh)->hh_next) {                           \
+            (delhh)->hh_next->hh_prev = (delhh)->hh_prev; \
+        }                                                 \
+    } while (0)
 
 /* Bucket expansion has the effect of doubling the number of buckets
  * and redistributing the items into the new buckets. Ideally the
@@ -912,306 +949,307 @@ do {                                                                            
  *      ceil(n/b) = (n>>lb) + ( (n & (b-1)) ? 1:0)
  *
  */
-#define HASH_EXPAND_BUCKETS(hh,tbl,oomed)                                        \
-do {                                                                             \
-  unsigned _he_bkt;                                                              \
-  unsigned _he_bkt_i;                                                            \
-  struct UT_hash_handle *_he_thh, *_he_hh_nxt;                                   \
-  UT_hash_bucket *_he_new_buckets, *_he_newbkt;                                  \
-  _he_new_buckets = (UT_hash_bucket*)uthash_malloc(                              \
-           2UL * (tbl)->num_buckets * sizeof(struct UT_hash_bucket));            \
-  if (!_he_new_buckets) {                                                        \
-    HASH_RECORD_OOM(oomed);                                                      \
-  } else {                                                                       \
-    uthash_bzero(_he_new_buckets,                                                \
-        2UL * (tbl)->num_buckets * sizeof(struct UT_hash_bucket));               \
-    (tbl)->ideal_chain_maxlen =                                                  \
-       ((tbl)->num_items >> ((tbl)->log2_num_buckets+1U)) +                      \
-       ((((tbl)->num_items & (((tbl)->num_buckets*2U)-1U)) != 0U) ? 1U : 0U);    \
-    (tbl)->nonideal_items = 0;                                                   \
-    for (_he_bkt_i = 0; _he_bkt_i < (tbl)->num_buckets; _he_bkt_i++) {           \
-      _he_thh = (tbl)->buckets[ _he_bkt_i ].hh_head;                             \
-      while (_he_thh != NULL) {                                                  \
-        _he_hh_nxt = _he_thh->hh_next;                                           \
-        HASH_TO_BKT(_he_thh->hashv, (tbl)->num_buckets * 2U, _he_bkt);           \
-        _he_newbkt = &(_he_new_buckets[_he_bkt]);                                \
-        if (++(_he_newbkt->count) > (tbl)->ideal_chain_maxlen) {                 \
-          (tbl)->nonideal_items++;                                               \
-          _he_newbkt->expand_mult = _he_newbkt->count / (tbl)->ideal_chain_maxlen; \
-        }                                                                        \
-        _he_thh->hh_prev = NULL;                                                 \
-        _he_thh->hh_next = _he_newbkt->hh_head;                                  \
-        if (_he_newbkt->hh_head != NULL) {                                       \
-          _he_newbkt->hh_head->hh_prev = _he_thh;                                \
-        }                                                                        \
-        _he_newbkt->hh_head = _he_thh;                                           \
-        _he_thh = _he_hh_nxt;                                                    \
-      }                                                                          \
-    }                                                                            \
-    uthash_free((tbl)->buckets, (tbl)->num_buckets * sizeof(struct UT_hash_bucket)); \
-    (tbl)->num_buckets *= 2U;                                                    \
-    (tbl)->log2_num_buckets++;                                                   \
-    (tbl)->buckets = _he_new_buckets;                                            \
-    (tbl)->ineff_expands = ((tbl)->nonideal_items > ((tbl)->num_items >> 1)) ?   \
-        ((tbl)->ineff_expands+1U) : 0U;                                          \
-    if ((tbl)->ineff_expands > 1U) {                                             \
-      (tbl)->noexpand = 1;                                                       \
-      uthash_noexpand_fyi(tbl);                                                  \
-    }                                                                            \
-    uthash_expand_fyi(tbl);                                                      \
-  }                                                                              \
-} while (0)
-
+#define HASH_EXPAND_BUCKETS(hh, tbl, oomed)                                                      \
+    do {                                                                                         \
+        unsigned _he_bkt;                                                                        \
+        unsigned _he_bkt_i;                                                                      \
+        struct UT_hash_handle *_he_thh, *_he_hh_nxt;                                             \
+        UT_hash_bucket *_he_new_buckets, *_he_newbkt;                                            \
+        _he_new_buckets = (UT_hash_bucket *)uthash_malloc(                                       \
+            2UL * (tbl)->num_buckets * sizeof(struct UT_hash_bucket));                           \
+        if (!_he_new_buckets) {                                                                  \
+            HASH_RECORD_OOM(oomed);                                                              \
+        } else {                                                                                 \
+            uthash_bzero(                                                                        \
+                _he_new_buckets, 2UL * (tbl)->num_buckets * sizeof(struct UT_hash_bucket));      \
+            (tbl)->ideal_chain_maxlen = ((tbl)->num_items >> ((tbl)->log2_num_buckets + 1U))     \
+                + ((((tbl)->num_items & (((tbl)->num_buckets * 2U) - 1U)) != 0U) ? 1U : 0U);     \
+            (tbl)->nonideal_items = 0;                                                           \
+            for (_he_bkt_i = 0; _he_bkt_i < (tbl)->num_buckets; _he_bkt_i++) {                   \
+                _he_thh = (tbl)->buckets[_he_bkt_i].hh_head;                                     \
+                while (_he_thh != NULL) {                                                        \
+                    _he_hh_nxt = _he_thh->hh_next;                                               \
+                    HASH_TO_BKT(_he_thh->hashv, (tbl)->num_buckets * 2U, _he_bkt);               \
+                    _he_newbkt = &(_he_new_buckets[_he_bkt]);                                    \
+                    if (++(_he_newbkt->count) > (tbl)->ideal_chain_maxlen) {                     \
+                        (tbl)->nonideal_items++;                                                 \
+                        _he_newbkt->expand_mult = _he_newbkt->count / (tbl)->ideal_chain_maxlen; \
+                    }                                                                            \
+                    _he_thh->hh_prev = NULL;                                                     \
+                    _he_thh->hh_next = _he_newbkt->hh_head;                                      \
+                    if (_he_newbkt->hh_head != NULL) {                                           \
+                        _he_newbkt->hh_head->hh_prev = _he_thh;                                  \
+                    }                                                                            \
+                    _he_newbkt->hh_head = _he_thh;                                               \
+                    _he_thh = _he_hh_nxt;                                                        \
+                }                                                                                \
+            }                                                                                    \
+            uthash_free((tbl)->buckets, (tbl)->num_buckets * sizeof(struct UT_hash_bucket));     \
+            (tbl)->num_buckets *= 2U;                                                            \
+            (tbl)->log2_num_buckets++;                                                           \
+            (tbl)->buckets = _he_new_buckets;                                                    \
+            (tbl)->ineff_expands = ((tbl)->nonideal_items > ((tbl)->num_items >> 1))             \
+                ? ((tbl)->ineff_expands + 1U)                                                    \
+                : 0U;                                                                            \
+            if ((tbl)->ineff_expands > 1U) {                                                     \
+                (tbl)->noexpand = 1;                                                             \
+                uthash_noexpand_fyi(tbl);                                                        \
+            }                                                                                    \
+            uthash_expand_fyi(tbl);                                                              \
+        }                                                                                        \
+    } while (0)
 
 /* This is an adaptation of Simon Tatham's O(n log(n)) mergesort */
 /* Note that HASH_SORT assumes the hash handle name to be hh.
  * HASH_SRT was added to allow the hash handle name to be passed in. */
-#define HASH_SORT(head,cmpfcn) HASH_SRT(hh,head,cmpfcn)
-#define HASH_SRT(hh,head,cmpfcn)                                                 \
-do {                                                                             \
-  unsigned _hs_i;                                                                \
-  unsigned _hs_looping,_hs_nmerges,_hs_insize,_hs_psize,_hs_qsize;               \
-  struct UT_hash_handle *_hs_p, *_hs_q, *_hs_e, *_hs_list, *_hs_tail;            \
-  if (head != NULL) {                                                            \
-    _hs_insize = 1;                                                              \
-    _hs_looping = 1;                                                             \
-    _hs_list = &((head)->hh);                                                    \
-    while (_hs_looping != 0U) {                                                  \
-      _hs_p = _hs_list;                                                          \
-      _hs_list = NULL;                                                           \
-      _hs_tail = NULL;                                                           \
-      _hs_nmerges = 0;                                                           \
-      while (_hs_p != NULL) {                                                    \
-        _hs_nmerges++;                                                           \
-        _hs_q = _hs_p;                                                           \
-        _hs_psize = 0;                                                           \
-        for (_hs_i = 0; _hs_i < _hs_insize; ++_hs_i) {                           \
-          _hs_psize++;                                                           \
-          _hs_q = ((_hs_q->next != NULL) ?                                       \
-            HH_FROM_ELMT((head)->hh.tbl, _hs_q->next) : NULL);                   \
-          if (_hs_q == NULL) {                                                   \
-            break;                                                               \
-          }                                                                      \
-        }                                                                        \
-        _hs_qsize = _hs_insize;                                                  \
-        while ((_hs_psize != 0U) || ((_hs_qsize != 0U) && (_hs_q != NULL))) {    \
-          if (_hs_psize == 0U) {                                                 \
-            _hs_e = _hs_q;                                                       \
-            _hs_q = ((_hs_q->next != NULL) ?                                     \
-              HH_FROM_ELMT((head)->hh.tbl, _hs_q->next) : NULL);                 \
-            _hs_qsize--;                                                         \
-          } else if ((_hs_qsize == 0U) || (_hs_q == NULL)) {                     \
-            _hs_e = _hs_p;                                                       \
-            if (_hs_p != NULL) {                                                 \
-              _hs_p = ((_hs_p->next != NULL) ?                                   \
-                HH_FROM_ELMT((head)->hh.tbl, _hs_p->next) : NULL);               \
-            }                                                                    \
-            _hs_psize--;                                                         \
-          } else if ((cmpfcn(                                                    \
-                DECLTYPE(head)(ELMT_FROM_HH((head)->hh.tbl, _hs_p)),             \
-                DECLTYPE(head)(ELMT_FROM_HH((head)->hh.tbl, _hs_q))              \
-                )) <= 0) {                                                       \
-            _hs_e = _hs_p;                                                       \
-            if (_hs_p != NULL) {                                                 \
-              _hs_p = ((_hs_p->next != NULL) ?                                   \
-                HH_FROM_ELMT((head)->hh.tbl, _hs_p->next) : NULL);               \
-            }                                                                    \
-            _hs_psize--;                                                         \
-          } else {                                                               \
-            _hs_e = _hs_q;                                                       \
-            _hs_q = ((_hs_q->next != NULL) ?                                     \
-              HH_FROM_ELMT((head)->hh.tbl, _hs_q->next) : NULL);                 \
-            _hs_qsize--;                                                         \
-          }                                                                      \
-          if ( _hs_tail != NULL ) {                                              \
-            _hs_tail->next = ((_hs_e != NULL) ?                                  \
-              ELMT_FROM_HH((head)->hh.tbl, _hs_e) : NULL);                       \
-          } else {                                                               \
-            _hs_list = _hs_e;                                                    \
-          }                                                                      \
-          if (_hs_e != NULL) {                                                   \
-            _hs_e->prev = ((_hs_tail != NULL) ?                                  \
-              ELMT_FROM_HH((head)->hh.tbl, _hs_tail) : NULL);                    \
-          }                                                                      \
-          _hs_tail = _hs_e;                                                      \
-        }                                                                        \
-        _hs_p = _hs_q;                                                           \
-      }                                                                          \
-      if (_hs_tail != NULL) {                                                    \
-        _hs_tail->next = NULL;                                                   \
-      }                                                                          \
-      if (_hs_nmerges <= 1U) {                                                   \
-        _hs_looping = 0;                                                         \
-        (head)->hh.tbl->tail = _hs_tail;                                         \
-        DECLTYPE_ASSIGN(head, ELMT_FROM_HH((head)->hh.tbl, _hs_list));           \
-      }                                                                          \
-      _hs_insize *= 2U;                                                          \
-    }                                                                            \
-    HASH_FSCK(hh, head, "HASH_SRT");                                             \
-  }                                                                              \
-} while (0)
+#define HASH_SORT(head, cmpfcn) HASH_SRT(hh, head, cmpfcn)
+#define HASH_SRT(hh, head, cmpfcn)                                                                 \
+    do {                                                                                           \
+        unsigned _hs_i;                                                                            \
+        unsigned _hs_looping, _hs_nmerges, _hs_insize, _hs_psize, _hs_qsize;                       \
+        struct UT_hash_handle *_hs_p, *_hs_q, *_hs_e, *_hs_list, *_hs_tail;                        \
+        if (head != NULL) {                                                                        \
+            _hs_insize = 1;                                                                        \
+            _hs_looping = 1;                                                                       \
+            _hs_list = &((head)->hh);                                                              \
+            while (_hs_looping != 0U) {                                                            \
+                _hs_p = _hs_list;                                                                  \
+                _hs_list = NULL;                                                                   \
+                _hs_tail = NULL;                                                                   \
+                _hs_nmerges = 0;                                                                   \
+                while (_hs_p != NULL) {                                                            \
+                    _hs_nmerges++;                                                                 \
+                    _hs_q = _hs_p;                                                                 \
+                    _hs_psize = 0;                                                                 \
+                    for (_hs_i = 0; _hs_i < _hs_insize; ++_hs_i) {                                 \
+                        _hs_psize++;                                                               \
+                        _hs_q = ((_hs_q->next != NULL) ? HH_FROM_ELMT((head)->hh.tbl, _hs_q->next) \
+                                                       : NULL);                                    \
+                        if (_hs_q == NULL) {                                                       \
+                            break;                                                                 \
+                        }                                                                          \
+                    }                                                                              \
+                    _hs_qsize = _hs_insize;                                                        \
+                    while ((_hs_psize != 0U) || ((_hs_qsize != 0U) && (_hs_q != NULL))) {          \
+                        if (_hs_psize == 0U) {                                                     \
+                            _hs_e = _hs_q;                                                         \
+                            _hs_q = ((_hs_q->next != NULL)                                         \
+                                    ? HH_FROM_ELMT((head)->hh.tbl, _hs_q->next)                    \
+                                    : NULL);                                                       \
+                            _hs_qsize--;                                                           \
+                        } else if ((_hs_qsize == 0U) || (_hs_q == NULL)) {                         \
+                            _hs_e = _hs_p;                                                         \
+                            if (_hs_p != NULL) {                                                   \
+                                _hs_p = ((_hs_p->next != NULL)                                     \
+                                        ? HH_FROM_ELMT((head)->hh.tbl, _hs_p->next)                \
+                                        : NULL);                                                   \
+                            }                                                                      \
+                            _hs_psize--;                                                           \
+                        } else if ((cmpfcn(DECLTYPE(head)(ELMT_FROM_HH((head)->hh.tbl, _hs_p)),    \
+                                       DECLTYPE(head)(ELMT_FROM_HH((head)->hh.tbl, _hs_q))))       \
+                            <= 0) {                                                                \
+                            _hs_e = _hs_p;                                                         \
+                            if (_hs_p != NULL) {                                                   \
+                                _hs_p = ((_hs_p->next != NULL)                                     \
+                                        ? HH_FROM_ELMT((head)->hh.tbl, _hs_p->next)                \
+                                        : NULL);                                                   \
+                            }                                                                      \
+                            _hs_psize--;                                                           \
+                        } else {                                                                   \
+                            _hs_e = _hs_q;                                                         \
+                            _hs_q = ((_hs_q->next != NULL)                                         \
+                                    ? HH_FROM_ELMT((head)->hh.tbl, _hs_q->next)                    \
+                                    : NULL);                                                       \
+                            _hs_qsize--;                                                           \
+                        }                                                                          \
+                        if (_hs_tail != NULL) {                                                    \
+                            _hs_tail->next                                                         \
+                                = ((_hs_e != NULL) ? ELMT_FROM_HH((head)->hh.tbl, _hs_e) : NULL);  \
+                        } else {                                                                   \
+                            _hs_list = _hs_e;                                                      \
+                        }                                                                          \
+                        if (_hs_e != NULL) {                                                       \
+                            _hs_e->prev                                                            \
+                                = ((_hs_tail != NULL) ? ELMT_FROM_HH((head)->hh.tbl, _hs_tail)     \
+                                                      : NULL);                                     \
+                        }                                                                          \
+                        _hs_tail = _hs_e;                                                          \
+                    }                                                                              \
+                    _hs_p = _hs_q;                                                                 \
+                }                                                                                  \
+                if (_hs_tail != NULL) {                                                            \
+                    _hs_tail->next = NULL;                                                         \
+                }                                                                                  \
+                if (_hs_nmerges <= 1U) {                                                           \
+                    _hs_looping = 0;                                                               \
+                    (head)->hh.tbl->tail = _hs_tail;                                               \
+                    DECLTYPE_ASSIGN(head, ELMT_FROM_HH((head)->hh.tbl, _hs_list));                 \
+                }                                                                                  \
+                _hs_insize *= 2U;                                                                  \
+            }                                                                                      \
+            HASH_FSCK(hh, head, "HASH_SRT");                                                       \
+        }                                                                                          \
+    } while (0)
 
 /* This function selects items from one hash into another hash.
  * The end result is that the selected items have dual presence
  * in both hashes. There is no copy of the items made; rather
  * they are added into the new hash through a secondary hash
  * hash handle that must be present in the structure. */
-#define HASH_SELECT(hh_dst, dst, hh_src, src, cond)                              \
-do {                                                                             \
-  unsigned _src_bkt, _dst_bkt;                                                   \
-  void *_last_elt = NULL, *_elt;                                                 \
-  UT_hash_handle *_src_hh, *_dst_hh, *_last_elt_hh=NULL;                         \
-  ptrdiff_t _dst_hho = ((char*)(&(dst)->hh_dst) - (char*)(dst));                 \
-  if ((src) != NULL) {                                                           \
-    for (_src_bkt=0; _src_bkt < (src)->hh_src.tbl->num_buckets; _src_bkt++) {    \
-      for (_src_hh = (src)->hh_src.tbl->buckets[_src_bkt].hh_head;               \
-        _src_hh != NULL;                                                         \
-        _src_hh = _src_hh->hh_next) {                                            \
-        _elt = ELMT_FROM_HH((src)->hh_src.tbl, _src_hh);                         \
-        if (cond(_elt)) {                                                        \
-          IF_HASH_NONFATAL_OOM( int _hs_oomed = 0; )                             \
-          _dst_hh = (UT_hash_handle*)(((char*)_elt) + _dst_hho);                 \
-          _dst_hh->key = _src_hh->key;                                           \
-          _dst_hh->keylen = _src_hh->keylen;                                     \
-          _dst_hh->hashv = _src_hh->hashv;                                       \
-          _dst_hh->prev = _last_elt;                                             \
-          _dst_hh->next = NULL;                                                  \
-          if (_last_elt_hh != NULL) {                                            \
-            _last_elt_hh->next = _elt;                                           \
-          }                                                                      \
-          if ((dst) == NULL) {                                                   \
-            DECLTYPE_ASSIGN(dst, _elt);                                          \
-            HASH_MAKE_TABLE(hh_dst, dst, _hs_oomed);                             \
-            IF_HASH_NONFATAL_OOM(                                                \
-              if (_hs_oomed) {                                                   \
-                uthash_nonfatal_oom(_elt);                                       \
-                (dst) = NULL;                                                    \
-                continue;                                                        \
-              }                                                                  \
-            )                                                                    \
-          } else {                                                               \
-            _dst_hh->tbl = (dst)->hh_dst.tbl;                                    \
-          }                                                                      \
-          HASH_TO_BKT(_dst_hh->hashv, _dst_hh->tbl->num_buckets, _dst_bkt);      \
-          HASH_ADD_TO_BKT(_dst_hh->tbl->buckets[_dst_bkt], hh_dst, _dst_hh, _hs_oomed); \
-          (dst)->hh_dst.tbl->num_items++;                                        \
-          IF_HASH_NONFATAL_OOM(                                                  \
-            if (_hs_oomed) {                                                     \
-              HASH_ROLLBACK_BKT(hh_dst, dst, _dst_hh);                           \
-              HASH_DELETE_HH(hh_dst, dst, _dst_hh);                              \
-              _dst_hh->tbl = NULL;                                               \
-              uthash_nonfatal_oom(_elt);                                         \
-              continue;                                                          \
-            }                                                                    \
-          )                                                                      \
-          HASH_BLOOM_ADD(_dst_hh->tbl, _dst_hh->hashv);                          \
-          _last_elt = _elt;                                                      \
-          _last_elt_hh = _dst_hh;                                                \
-        }                                                                        \
-      }                                                                          \
-    }                                                                            \
-  }                                                                              \
-  HASH_FSCK(hh_dst, dst, "HASH_SELECT");                                         \
-} while (0)
+#define HASH_SELECT(hh_dst, dst, hh_src, src, cond)                                           \
+    do {                                                                                      \
+        unsigned _src_bkt, _dst_bkt;                                                          \
+        void *_last_elt = NULL, *_elt;                                                        \
+        UT_hash_handle *_src_hh, *_dst_hh, *_last_elt_hh = NULL;                              \
+        ptrdiff_t _dst_hho = ((char *)(&(dst)->hh_dst) - (char *)(dst));                      \
+        if ((src) != NULL) {                                                                  \
+            for (_src_bkt = 0; _src_bkt < (src)->hh_src.tbl->num_buckets; _src_bkt++) {       \
+                for (_src_hh = (src)->hh_src.tbl->buckets[_src_bkt].hh_head; _src_hh != NULL; \
+                     _src_hh = _src_hh->hh_next) {                                            \
+                    _elt = ELMT_FROM_HH((src)->hh_src.tbl, _src_hh);                          \
+                    if (cond(_elt)) {                                                         \
+                        IF_HASH_NONFATAL_OOM(int _hs_oomed = 0;)                              \
+                        _dst_hh = (UT_hash_handle *)(((char *)_elt) + _dst_hho);              \
+                        _dst_hh->key = _src_hh->key;                                          \
+                        _dst_hh->keylen = _src_hh->keylen;                                    \
+                        _dst_hh->hashv = _src_hh->hashv;                                      \
+                        _dst_hh->prev = _last_elt;                                            \
+                        _dst_hh->next = NULL;                                                 \
+                        if (_last_elt_hh != NULL) {                                           \
+                            _last_elt_hh->next = _elt;                                        \
+                        }                                                                     \
+                        if ((dst) == NULL) {                                                  \
+                            DECLTYPE_ASSIGN(dst, _elt);                                       \
+                            HASH_MAKE_TABLE(hh_dst, dst, _hs_oomed);                          \
+                            IF_HASH_NONFATAL_OOM(if (_hs_oomed) {                             \
+                                uthash_nonfatal_oom(_elt);                                    \
+                                (dst) = NULL;                                                 \
+                                continue;                                                     \
+                            })                                                                \
+                        } else {                                                              \
+                            _dst_hh->tbl = (dst)->hh_dst.tbl;                                 \
+                        }                                                                     \
+                        HASH_TO_BKT(_dst_hh->hashv, _dst_hh->tbl->num_buckets, _dst_bkt);     \
+                        HASH_ADD_TO_BKT(                                                      \
+                            _dst_hh->tbl->buckets[_dst_bkt], hh_dst, _dst_hh, _hs_oomed);     \
+                        (dst)->hh_dst.tbl->num_items++;                                       \
+                        IF_HASH_NONFATAL_OOM(if (_hs_oomed) {                                 \
+                            HASH_ROLLBACK_BKT(hh_dst, dst, _dst_hh);                          \
+                            HASH_DELETE_HH(hh_dst, dst, _dst_hh);                             \
+                            _dst_hh->tbl = NULL;                                              \
+                            uthash_nonfatal_oom(_elt);                                        \
+                            continue;                                                         \
+                        })                                                                    \
+                        HASH_BLOOM_ADD(_dst_hh->tbl, _dst_hh->hashv);                         \
+                        _last_elt = _elt;                                                     \
+                        _last_elt_hh = _dst_hh;                                               \
+                    }                                                                         \
+                }                                                                             \
+            }                                                                                 \
+        }                                                                                     \
+        HASH_FSCK(hh_dst, dst, "HASH_SELECT");                                                \
+    } while (0)
 
-#define HASH_CLEAR(hh,head)                                                      \
-do {                                                                             \
-  if ((head) != NULL) {                                                          \
-    HASH_BLOOM_FREE((head)->hh.tbl);                                             \
-    uthash_free((head)->hh.tbl->buckets,                                         \
-                (head)->hh.tbl->num_buckets*sizeof(struct UT_hash_bucket));      \
-    uthash_free((head)->hh.tbl, sizeof(UT_hash_table));                          \
-    (head) = NULL;                                                               \
-  }                                                                              \
-} while (0)
+#define HASH_CLEAR(hh, head)                                                  \
+    do {                                                                      \
+        if ((head) != NULL) {                                                 \
+            HASH_BLOOM_FREE((head)->hh.tbl);                                  \
+            uthash_free((head)->hh.tbl->buckets,                              \
+                (head)->hh.tbl->num_buckets * sizeof(struct UT_hash_bucket)); \
+            uthash_free((head)->hh.tbl, sizeof(UT_hash_table));               \
+            (head) = NULL;                                                    \
+        }                                                                     \
+    } while (0)
 
-#define HASH_OVERHEAD(hh,head)                                                   \
- (((head) != NULL) ? (                                                           \
- (size_t)(((head)->hh.tbl->num_items   * sizeof(UT_hash_handle))   +             \
-          ((head)->hh.tbl->num_buckets * sizeof(UT_hash_bucket))   +             \
-           sizeof(UT_hash_table)                                   +             \
-           (HASH_BLOOM_BYTELEN))) : 0U)
+#define HASH_OVERHEAD(hh, head)                                                           \
+    (((head) != NULL) ? ((size_t)(((head)->hh.tbl->num_items * sizeof(UT_hash_handle))    \
+         + ((head)->hh.tbl->num_buckets * sizeof(UT_hash_bucket)) + sizeof(UT_hash_table) \
+         + (HASH_BLOOM_BYTELEN)))                                                         \
+                      : 0U)
 
 #ifdef NO_DECLTYPE
-#define HASH_ITER(hh,head,el,tmp)                                                \
-for(((el)=(head)), ((*(char**)(&(tmp)))=(char*)((head!=NULL)?(head)->hh.next:NULL)); \
-  (el) != NULL; ((el)=(tmp)), ((*(char**)(&(tmp)))=(char*)((tmp!=NULL)?(tmp)->hh.next:NULL)))
+#define HASH_ITER(hh, head, el, tmp)                                                 \
+    for (((el) = (head)),                                                            \
+         ((*(char **)(&(tmp))) = (char *)((head != NULL) ? (head)->hh.next : NULL)); \
+         (el) != NULL;                                                               \
+         ((el) = (tmp)), ((*(char **)(&(tmp))) = (char *)((tmp != NULL) ? (tmp)->hh.next : NULL)))
 #else
-#define HASH_ITER(hh,head,el,tmp)                                                \
-for(((el)=(head)), ((tmp)=DECLTYPE(el)((head!=NULL)?(head)->hh.next:NULL));      \
-  (el) != NULL; ((el)=(tmp)), ((tmp)=DECLTYPE(el)((tmp!=NULL)?(tmp)->hh.next:NULL)))
+#define HASH_ITER(hh, head, el, tmp)                                                       \
+    for (((el) = (head)), ((tmp) = DECLTYPE(el)((head != NULL) ? (head)->hh.next : NULL)); \
+         (el) != NULL;                                                                     \
+         ((el) = (tmp)), ((tmp) = DECLTYPE(el)((tmp != NULL) ? (tmp)->hh.next : NULL)))
 #endif
 
 /* obtain a count of items in the hash */
-#define HASH_COUNT(head) HASH_CNT(hh,head)
-#define HASH_CNT(hh,head) ((head != NULL)?((head)->hh.tbl->num_items):0U)
+#define HASH_COUNT(head)   HASH_CNT(hh, head)
+#define HASH_CNT(hh, head) ((head != NULL) ? ((head)->hh.tbl->num_items) : 0U)
 
 typedef struct UT_hash_bucket {
-   struct UT_hash_handle *hh_head;
-   unsigned count;
+    struct UT_hash_handle *hh_head;
+    unsigned count;
 
-   /* expand_mult is normally set to 0. In this situation, the max chain length
-    * threshold is enforced at its default value, HASH_BKT_CAPACITY_THRESH. (If
-    * the bucket's chain exceeds this length, bucket expansion is triggered).
-    * However, setting expand_mult to a non-zero value delays bucket expansion
-    * (that would be triggered by additions to this particular bucket)
-    * until its chain length reaches a *multiple* of HASH_BKT_CAPACITY_THRESH.
-    * (The multiplier is simply expand_mult+1). The whole idea of this
-    * multiplier is to reduce bucket expansions, since they are expensive, in
-    * situations where we know that a particular bucket tends to be overused.
-    * It is better to let its chain length grow to a longer yet-still-bounded
-    * value, than to do an O(n) bucket expansion too often.
-    */
-   unsigned expand_mult;
+    /* expand_mult is normally set to 0. In this situation, the max chain length
+     * threshold is enforced at its default value, HASH_BKT_CAPACITY_THRESH. (If
+     * the bucket's chain exceeds this length, bucket expansion is triggered).
+     * However, setting expand_mult to a non-zero value delays bucket expansion
+     * (that would be triggered by additions to this particular bucket)
+     * until its chain length reaches a *multiple* of HASH_BKT_CAPACITY_THRESH.
+     * (The multiplier is simply expand_mult+1). The whole idea of this
+     * multiplier is to reduce bucket expansions, since they are expensive, in
+     * situations where we know that a particular bucket tends to be overused.
+     * It is better to let its chain length grow to a longer yet-still-bounded
+     * value, than to do an O(n) bucket expansion too often.
+     */
+    unsigned expand_mult;
 
 } UT_hash_bucket;
 
 /* random signature used only to find hash tables in external analysis */
-#define HASH_SIGNATURE 0xa0111fe1u
+#define HASH_SIGNATURE       0xa0111fe1u
 #define HASH_BLOOM_SIGNATURE 0xb12220f2u
 
 typedef struct UT_hash_table {
-   UT_hash_bucket *buckets;
-   unsigned num_buckets, log2_num_buckets;
-   unsigned num_items;
-   struct UT_hash_handle *tail; /* tail hh in app order, for fast append    */
-   ptrdiff_t hho; /* hash handle offset (byte pos of hash handle in element */
+    UT_hash_bucket *buckets;
+    unsigned num_buckets, log2_num_buckets;
+    unsigned num_items;
+    struct UT_hash_handle *tail; /* tail hh in app order, for fast append    */
+    ptrdiff_t hho; /* hash handle offset (byte pos of hash handle in element */
 
-   /* in an ideal situation (all buckets used equally), no bucket would have
-    * more than ceil(#items/#buckets) items. that's the ideal chain length. */
-   unsigned ideal_chain_maxlen;
+    /* in an ideal situation (all buckets used equally), no bucket would have
+     * more than ceil(#items/#buckets) items. that's the ideal chain length. */
+    unsigned ideal_chain_maxlen;
 
-   /* nonideal_items is the number of items in the hash whose chain position
-    * exceeds the ideal chain maxlen. these items pay the penalty for an uneven
-    * hash distribution; reaching them in a chain traversal takes >ideal steps */
-   unsigned nonideal_items;
+    /* nonideal_items is the number of items in the hash whose chain position
+     * exceeds the ideal chain maxlen. these items pay the penalty for an uneven
+     * hash distribution; reaching them in a chain traversal takes >ideal steps */
+    unsigned nonideal_items;
 
-   /* ineffective expands occur when a bucket doubling was performed, but
-    * afterward, more than half the items in the hash had nonideal chain
-    * positions. If this happens on two consecutive expansions we inhibit any
-    * further expansion, as it's not helping; this happens when the hash
-    * function isn't a good fit for the key domain. When expansion is inhibited
-    * the hash will still work, albeit no longer in constant time. */
-   unsigned ineff_expands, noexpand;
+    /* ineffective expands occur when a bucket doubling was performed, but
+     * afterward, more than half the items in the hash had nonideal chain
+     * positions. If this happens on two consecutive expansions we inhibit any
+     * further expansion, as it's not helping; this happens when the hash
+     * function isn't a good fit for the key domain. When expansion is inhibited
+     * the hash will still work, albeit no longer in constant time. */
+    unsigned ineff_expands, noexpand;
 
-   uint32_t signature; /* used only to find hash tables in external analysis */
+    uint32_t signature; /* used only to find hash tables in external analysis */
 #ifdef HASH_BLOOM
-   uint32_t bloom_sig; /* used only to test bloom exists in external analysis */
-   uint8_t *bloom_bv;
-   uint8_t bloom_nbits;
+    uint32_t bloom_sig; /* used only to test bloom exists in external analysis */
+    uint8_t *bloom_bv;
+    uint8_t bloom_nbits;
 #endif
 
 } UT_hash_table;
 
 typedef struct UT_hash_handle {
-   struct UT_hash_table *tbl;
-   void *prev;                       /* prev element in app order      */
-   void *next;                       /* next element in app order      */
-   struct UT_hash_handle *hh_prev;   /* previous hh in bucket order    */
-   struct UT_hash_handle *hh_next;   /* next hh in bucket order        */
-   void *key;                        /* ptr to enclosing struct's key  */
-   unsigned keylen;                  /* enclosing struct's key len     */
-   unsigned hashv;                   /* result of hash-fcn(key)        */
+    struct UT_hash_table *tbl;
+    void *prev; /* prev element in app order      */
+    void *next; /* next element in app order      */
+    struct UT_hash_handle *hh_prev; /* previous hh in bucket order    */
+    struct UT_hash_handle *hh_next; /* next hh in bucket order        */
+    void *key; /* ptr to enclosing struct's key  */
+    unsigned keylen; /* enclosing struct's key len     */
+    unsigned hashv; /* result of hash-fcn(key)        */
 } UT_hash_handle;
 
 #endif /* UTHASH_H */

--- a/mf_test.c
+++ b/mf_test.c
@@ -4,29 +4,26 @@
 
 void c2(char *argv)
 {
-	char *s = strdup(argv);
-	printf("call 3a: %p\n", malloc(10));
-	printf("call 3b: %p\n", realloc(NULL, 10));
-	printf("call 3c: %p\n", s);
+    char *s = strdup(argv);
+    printf("call 3a: %p\n", malloc(10));
+    printf("call 3b: %p\n", realloc(NULL, 10));
+    printf("call 3c: %p\n", s);
 }
-
 
 void c1(char *argv)
 {
-	printf("call 2a: %p\n", malloc(10));
-	printf("call 2b: %p\n", realloc(NULL, 10));
-	printf("call 2c: %p\n", strdup(argv));
-	c2(argv);
+    printf("call 2a: %p\n", malloc(10));
+    printf("call 2b: %p\n", realloc(NULL, 10));
+    printf("call 2c: %p\n", strdup(argv));
+    c2(argv);
 }
-
 
 int main(int argc, char *argv[])
 {
-	printf("call 1a: %p\n", malloc(10));
-	printf("call 1b: %p\n", realloc(NULL, 10));
-	printf("call 1c: %p\n", strdup(argv[0]));
-	c1(argv[0]);
-	c1(argv[0]);
-	return 0;
+    printf("call 1a: %p\n", malloc(10));
+    printf("call 1b: %p\n", realloc(NULL, 10));
+    printf("call 1c: %p\n", strdup(argv[0]));
+    c1(argv[0]);
+    c1(argv[0]);
+    return 0;
 }
-

--- a/src/mallocfail.c
+++ b/src/mallocfail.c
@@ -16,24 +16,27 @@ efficient and reliable than e.g. random testing.
 
 */
 
+#define _GNU_SOURCE
+
 #define uthash_malloc libc_malloc
 
-#include "uthash.h"
-#include "sha3.h"
-
-#include <stdio.h>
-#include <string.h>
+#include <dlfcn.h>
 #include <execinfo.h>
-
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 
+#include "sha3.h"
+#include "uthash.h"
+
+#define UNW_LOCAL_ONLY
+#include <libunwind.h>
 #include <unistd.h>
-#include <backtrace.h>
 
-#define HASH_BITS 256
-#define HASH_BYTES ((HASH_BITS)/8)
-#define HASH_HEX_BYTES ((HASH_BITS)/4)
+#define HASH_BITS      256
+#define HASH_BYTES     ((HASH_BITS) / 8)
+#define HASH_HEX_BYTES ((HASH_BITS) / 4)
 
 extern int force_libc;
 extern void *(*libc_malloc)(size_t);
@@ -41,202 +44,234 @@ extern void *(*libc_calloc)(size_t, size_t);
 extern void *(*libc_realloc)(void *, size_t);
 
 struct traces_s {
-	UT_hash_handle hh;
-	char hash[HASH_HEX_BYTES+1];
+    UT_hash_handle hh;
+    char hash[HASH_HEX_BYTES + 1];
 };
 
 static struct traces_s *traces = NULL;
-static struct backtrace_state *state = NULL;
 static char strbuf[1024];
 static char *hashfile = NULL;
 static char hashfile_default[] = "mallocfail_hashes";
 static int debug = -1;
-static int backtrace_count;
 static int fail_count = 0;
 static int max_fail_count = -1;
 
-
 static void hex_encode(const unsigned char *in, unsigned int in_len, char *encoded)
 {
-	int i;
-	for(i=0; i<in_len; i++){
-		sprintf(&encoded[i*2], "%02x", in[i]);
-	}
+    int i;
+    for (i = 0; i < in_len; i++) {
+        sprintf(&encoded[i * 2], "%02x", in[i]);
+    }
 }
-
 
 static int append_stack_context(const char *filename, const char *hash_str)
 {
-	FILE *fptr;
+    FILE *fptr;
 
-	struct traces_s *t = libc_malloc(sizeof(struct traces_s));
-	memcpy(t->hash, hash_str, HASH_HEX_BYTES);
-	t->hash[HASH_HEX_BYTES] = '\0';
-	HASH_ADD_STR(traces, hash, t);
+    struct traces_s *t = (struct traces_s *)libc_malloc(sizeof(struct traces_s));
+    memcpy(t->hash, hash_str, HASH_HEX_BYTES);
+    t->hash[HASH_HEX_BYTES] = '\0';
+    HASH_ADD_STR(traces, hash, t);
 
-	fptr = fopen(filename, "at");
-	if(!fptr){
-		return 1;
-	}
-	fprintf(fptr, "%s\n", hash_str);
+    fptr = fopen(filename, "at");
+    if (!fptr) {
+        return 1;
+    }
+    fprintf(fptr, "%s\n", hash_str);
 
-	fclose(fptr);
-	return 0;
+    fclose(fptr);
+    return 0;
 }
-
 
 static void load_traces(const char *filename)
 {
-	FILE *fptr;
-	char buf[1024];
+    FILE *fptr;
+    char buf[1024];
 
-	fptr = fopen(filename, "rt");
-	if(!fptr){
-		return;
-	}
+    fptr = fopen(filename, "rt");
+    if (!fptr) {
+        return;
+    }
 
-	while(!feof(fptr)){
-		if(fgets(buf, 1024, fptr)){
-			if(buf[strlen(buf)-1] == '\n'){
-				buf[strlen(buf)-1] = '\0';
-				
-				struct traces_s *t = libc_malloc(sizeof(struct traces_s));
-				memcpy(t->hash, buf, HASH_HEX_BYTES);
-				t->hash[HASH_HEX_BYTES] = '\0';
-				HASH_ADD_STR(traces, hash, t);
-			}
-		}
-	}
-	fclose(fptr);
+    while (!feof(fptr)) {
+        if (fgets(buf, 1024, fptr)) {
+            if (buf[strlen(buf) - 1] == '\n') {
+                buf[strlen(buf) - 1] = '\0';
+
+                struct traces_s *t = (struct traces_s *)libc_malloc(sizeof(struct traces_s));
+                memcpy(t->hash, buf, HASH_HEX_BYTES);
+                t->hash[HASH_HEX_BYTES] = '\0';
+                HASH_ADD_STR(traces, hash, t);
+            }
+        }
+    }
+    fclose(fptr);
 }
-
 
 static int stack_context_exists(const char *filename, const char *hash_str)
 {
-	struct traces_s *found_trace;
-	int rc;
+    struct traces_s *found_trace;
+    int rc;
 
-	force_libc = 1;
-	if(traces == NULL){
-		load_traces(filename);
-	}
+    force_libc = 1;
+    if (traces == NULL) {
+        load_traces(filename);
+    }
 
-	HASH_FIND_STR(traces, hash_str, found_trace);
-	if(found_trace){
-		rc = 1;
-	}else{
-		append_stack_context(filename, hash_str);
-		rc = 0;
-	}
+    HASH_FIND_STR(traces, hash_str, found_trace);
+    if (found_trace) {
+        rc = 1;
+    } else {
+        append_stack_context(filename, hash_str);
+        rc = 0;
+    }
 
-	force_libc = 0;
-	return rc;
+    force_libc = 0;
+    return rc;
 }
 
+static int (*libc_on_exit)(void);
 
-static int backtrace_callback(void *data, uintptr_t pc, const char *filename, int lineno, const char *function)
+static bool create_backtrace_hash(char *hash_str)
 {
-	int len;
-	sha3_context *hash_context = (sha3_context *)data;
+    const unsigned char *hash;
+    sha3_context hash_context;
 
-	if(lineno){
-		len = snprintf(strbuf, 1024, "%s:%s:%d\n", filename, function, lineno);
-		sha3_Update(hash_context, strbuf, len);
-	}
+    force_libc = 1;
 
-	return 0;
+    sha3_Init256(&hash_context);
+
+    if (!libc_on_exit) {
+        libc_on_exit = dlsym(RTLD_DEFAULT, "on_exit");
+    }
+
+#if DEBUG
+    fprintf(stderr, "------- Start trace -------\n");
+#endif
+    unw_cursor_t cursor;
+    unw_context_t uc;
+
+    unw_getcontext(&uc);
+    unw_init_local(&cursor, &uc);
+    while (unw_step(&cursor) > 0) {
+        unw_word_t ip, sp, off = 0;
+        unw_get_reg(&cursor, UNW_REG_IP, &ip);
+        unw_get_reg(&cursor, UNW_REG_SP, &sp);
+
+        unw_proc_info_t pi;
+        unw_get_proc_info(&cursor, &pi);
+
+        char symbol[256] = "<unknown>";
+        if (unw_get_proc_name(&cursor, symbol, sizeof(symbol), &off) != 0) {
+            Dl_info info = {0};
+            dladdr((void *)ip, &info);
+            void *stable_addr = (void *)((char *)ip - (char *)info.dli_fbase);
+
+            snprintf(symbol, sizeof(symbol), "%p", stable_addr);
+        }
+
+        if (memcmp(symbol, "_dl_", 4) == 0) {
+            return false;
+        }
+
+        if ((uintptr_t)libc_on_exit <= pi.end_ip && (uintptr_t)libc_on_exit >= pi.start_ip) {
+            return false;
+        }
+
+#if DEBUG
+        fprintf(stderr, "%s@%lx-%lx %lx %p\n", symbol, pi.start_ip, pi.end_ip, (long)off,
+            (void *)libc_on_exit);
+#endif
+        int len = snprintf(strbuf, 1024, "%s+%lx\n", symbol, (long)off);
+        sha3_Update(&hash_context, strbuf, len);
+    }
+
+    hash = sha3_Finalize(&hash_context);
+    hex_encode(hash, HASH_BYTES, hash_str);
+#if DEBUG
+    fprintf(stderr, "------- End trace -------\n");
+#endif
+
+    force_libc = 0;
+
+    return true;
 }
-
-
-static void create_backtrace_hash(char *hash_str)
-{
-	const unsigned char *hash;
-	sha3_context hash_context;
-
-	force_libc = 1;
-
-	sha3_Init256(&hash_context);
-	backtrace_full(state, 0, backtrace_callback, NULL, &hash_context);
-	hash = sha3_Finalize(&hash_context);
-	hex_encode(hash, HASH_BYTES, hash_str);
-
-	force_libc = 0;
-}
-
-
-static int backtrace_print_callback(void *data, uintptr_t pc, const char *filename, int lineno, const char *function)
-{
-	if(lineno && ++backtrace_count > -3){
-		printf("%s:%s:%d\n", filename, function, lineno);
-	}
-
-	return 0;
-}
-
 
 static void print_backtrace(void)
 {
-	force_libc = 1;
-	printf("------- Start trace -------\n");
-	backtrace_count = 0;
-	backtrace_full(state, 0, backtrace_print_callback, NULL, NULL);
-	printf("------- End trace -------\n");
-	force_libc = 0;
-}
+    force_libc = 1;
+    fprintf(stderr, "------- Start trace -------\n");
 
+    unw_cursor_t cursor;
+    unw_context_t uc;
+
+    unw_getcontext(&uc);
+    unw_init_local(&cursor, &uc);
+    while (unw_step(&cursor) > 0) {
+        unw_word_t ip, sp, off;
+        unw_get_reg(&cursor, UNW_REG_IP, &ip);
+        unw_get_reg(&cursor, UNW_REG_SP, &sp);
+
+        char symbol[256] = "<unknown>";
+        unw_get_proc_name(&cursor, symbol, sizeof(symbol), &off);
+
+        fprintf(stderr, "%s %lx\n", symbol, (long)off);
+    }
+
+    fprintf(stderr, "------- End trace -------\n");
+    force_libc = 0;
+}
 
 int should_malloc_fail(void)
 {
-	char hash_str[1024];
-	int exists;
+    char hash_str[1024];
+    int exists;
 
-	if(max_fail_count == -1){
-		char *env = getenv("MALLOCFAIL_FAIL_COUNT");
-		if(env){
-			max_fail_count = atoi(env);
-			if(max_fail_count < 0){
-				max_fail_count = 0;
-			}
-		}else{
-			max_fail_count = 0;
-		}
-	}
+    if (max_fail_count == -1) {
+        char *env = getenv("MALLOCFAIL_FAIL_COUNT");
+        if (env) {
+            max_fail_count = atoi(env);
+            if (max_fail_count < 0) {
+                max_fail_count = 0;
+            }
+        } else {
+            max_fail_count = 0;
+        }
+    }
 
-	if(max_fail_count > 0 && fail_count >= max_fail_count){
-		return 0;
-	}
+    if (max_fail_count > 0 && fail_count >= max_fail_count) {
+        return 0;
+    }
 
-	if(!state){
-		state = backtrace_create_state(NULL, 1, NULL, NULL);
-	}
+    force_libc = 1;
+    if (!hashfile) {
+        hashfile = getenv("MALLOCFAIL_FILE");
+        if (!hashfile) {
+            hashfile = hashfile_default;
+        }
+    }
 
-	force_libc = 1;
-	if(!hashfile){
-		hashfile = getenv("MALLOCFAIL_FILE");
-		if(!hashfile){
-			hashfile = hashfile_default;
-		}
-	}
+    if (debug == -1) {
+        if (getenv("MALLOCFAIL_DEBUG")) {
+            debug = 1;
+        } else {
+            debug = 0;
+        }
+    }
+    force_libc = 0;
 
-	if(debug == -1){
-		if(getenv("MALLOCFAIL_DEBUG")){
-			debug = 1;
-		}else{
-			debug = 0;
-		}
-	}
-	force_libc = 0;
+    if (!create_backtrace_hash(hash_str)) {
+        return 0;
+    }
 
-	create_backtrace_hash(hash_str);
-	exists = stack_context_exists(hashfile, hash_str);
-	if(!exists && debug){
-		print_backtrace();
-	}
-	if(exists){
-		return 0;
-	}else{
-		fail_count++;
-		return 1;
-	}
+    exists = stack_context_exists(hashfile, hash_str);
+    if (!exists && debug) {
+        print_backtrace();
+    }
+    if (exists) {
+        return 0;
+    } else {
+        fail_count++;
+        return 1;
+    }
 }
-

--- a/src/syscall_funcs.c
+++ b/src/syscall_funcs.c
@@ -1,0 +1,167 @@
+#define _GNU_SOURCE
+
+#include <dlfcn.h>
+#include <errno.h>
+#include <stdarg.h>
+#include <stdlib.h>
+#include <sys/ioctl.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+
+#include "mallocfail.h"
+
+static int (*libc_ioctl)(int fd, unsigned long request, ...);
+static int (*libc_bind)(int sockfd, const struct sockaddr *addr, socklen_t addrlen);
+static int (*libc_getsockopt)(int sockfd, int level, int optname, void *optval, socklen_t *optlen);
+static int (*libc_setsockopt)(
+    int sockfd, int level, int optname, const void *optval, socklen_t optlen);
+static ssize_t (*libc_recv)(int sockfd, void *buf, size_t len, int flags);
+static ssize_t (*libc_recvfrom)(
+    int sockfd, void *buf, size_t len, int flags, struct sockaddr *src_addr, socklen_t *addrlen);
+static ssize_t (*libc_send)(int sockfd, const void *buf, size_t len, int flags);
+static ssize_t (*libc_sendto)(int sockfd, const void *buf, size_t len, int flags,
+    const struct sockaddr *dest_addr, socklen_t addrlen);
+static int (*libc_socket)(int domain, int type, int protocol);
+static int (*libc_listen)(int sockfd, int backlog);
+
+static int (*libc_pthread_mutex_init)(pthread_mutex_t *mutex, const pthread_mutexattr_t *attr);
+
+__attribute__((__constructor__)) static void init(void)
+{
+    libc_ioctl = dlsym(RTLD_NEXT, "ioctl");
+    libc_bind = dlsym(RTLD_NEXT, "bind");
+    libc_getsockopt = dlsym(RTLD_NEXT, "getsockopt");
+    libc_setsockopt = dlsym(RTLD_NEXT, "setsockopt");
+    libc_recv = dlsym(RTLD_NEXT, "recv");
+    libc_recvfrom = dlsym(RTLD_NEXT, "recvfrom");
+    libc_send = dlsym(RTLD_NEXT, "send");
+    libc_sendto = dlsym(RTLD_NEXT, "sendto");
+    libc_socket = dlsym(RTLD_NEXT, "socket");
+    libc_listen = dlsym(RTLD_NEXT, "listen");
+    libc_pthread_mutex_init = dlsym(RTLD_NEXT, "pthread_mutex_init");
+}
+
+int ioctl(int fd, unsigned long request, ...)
+{
+    if (should_malloc_fail()) {
+        errno = ENOMEM;
+        return -1;
+    }
+
+    va_list ap;
+    va_start(ap, request);
+    const int ret = libc_ioctl(fd, SIOCGIFCONF, va_arg(ap, void *));
+    va_end(ap);
+    return ret;
+}
+
+int bind(int sockfd, const struct sockaddr *addr, socklen_t addrlen)
+{
+    // Unlike all others, if bind should fail once, it should fail always, because in toxcore we try
+    // many ports before giving up. If this only fails once, we'll never reach the code path where
+    // we give up.
+    static int should_fail = -1;
+
+    if (should_fail == -1) {
+        should_fail = should_malloc_fail();
+    }
+
+    if (should_fail) {
+        errno = ENOMEM;
+        return -1;
+    }
+
+    return libc_bind(sockfd, addr, addrlen);
+}
+
+int getsockopt(int sockfd, int level, int optname, void *optval, socklen_t *optlen)
+{
+    if (should_malloc_fail()) {
+        errno = ENOMEM;
+        return -1;
+    }
+
+    return libc_getsockopt(sockfd, level, optname, optval, optlen);
+}
+
+int setsockopt(int sockfd, int level, int optname, const void *optval, socklen_t optlen)
+{
+    if (should_malloc_fail()) {
+        errno = ENOMEM;
+        return -1;
+    }
+
+    return libc_setsockopt(sockfd, level, optname, optval, optlen);
+}
+
+ssize_t recv(int sockfd, void *buf, size_t len, int flags)
+{
+    if (should_malloc_fail()) {
+        errno = ENOMEM;
+        return -1;
+    }
+
+    return libc_recv(sockfd, buf, len, flags);
+}
+
+ssize_t recvfrom(
+    int sockfd, void *buf, size_t len, int flags, struct sockaddr *src_addr, socklen_t *addrlen)
+{
+    if (should_malloc_fail()) {
+        errno = ENOMEM;
+        return -1;
+    }
+
+    return libc_recvfrom(sockfd, buf, len, flags, src_addr, addrlen);
+}
+
+ssize_t send(int sockfd, const void *buf, size_t len, int flags)
+{
+    if (should_malloc_fail()) {
+        errno = ENOMEM;
+        return -1;
+    }
+
+    return libc_send(sockfd, buf, len, flags);
+}
+
+ssize_t sendto(int sockfd, const void *buf, size_t len, int flags, const struct sockaddr *dest_addr,
+    socklen_t addrlen)
+{
+    if (should_malloc_fail()) {
+        errno = ENOMEM;
+        return -1;
+    }
+
+    return libc_sendto(sockfd, buf, len, flags, dest_addr, addrlen);
+}
+
+int socket(int domain, int type, int protocol)
+{
+    if (should_malloc_fail()) {
+        errno = ENOMEM;
+        return -1;
+    }
+
+    return libc_socket(domain, type, protocol);
+}
+
+int listen(int sockfd, int backlog)
+{
+    if (should_malloc_fail()) {
+        errno = ENOMEM;
+        return -1;
+    }
+
+    return libc_listen(sockfd, backlog);
+}
+
+int pthread_mutex_init(pthread_mutex_t *mutex, const pthread_mutexattr_t *attr)
+{
+    if (should_malloc_fail()) {
+        errno = ENOMEM;
+        return -1;
+    }
+
+    return libc_pthread_mutex_init(mutex, attr);
+}


### PR DESCRIPTION
libunwind is available across compilers, while backtrace only works on gcc. This is a problem, because clang-17 produces dwarf codes that gcc's backtrace doesn't understand (it segfaults).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/mallocfail/4)
<!-- Reviewable:end -->
